### PR TITLE
feat: Update size preview, IzzyOnDroid buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ObtainX builds on everything Obtainium does well — same sources, same trust model, same spirit — with a reworked UI and a set of features aimed at making everyday use a little smoother. For a side-by-side comparison with screenshots, see [ObtainX vs Obtainium](./docs/Difference_with_Obtainium.md).
 
----
 
 ## ✨ New Features
 
@@ -20,6 +19,8 @@ Features that don't exist in Obtainium at all.
 
 - **🖼️ Custom app icons** — Not happy with an app's icon or a blank placeholder? Tap the icon on any app's detail page to set your own — pick from your gallery or grab one from the web.
 
+- **⚖️ Know the update size beforehand** — See the exact download size for every update a - across all supported stores — before you even hit the update button.
+
 - **⏭️ Skip Version** — Pass on a specific release you don't want without marking the app as "updated." The next release will still show up normally.
 
 - **🧩 Advanced filter / RegEx Assist** — A built-in helper walks you through building regex filters on any field that supports them. No regex knowledge required. Full details in the [Additional options guide](./additional-options-guide.md).
@@ -28,7 +29,6 @@ Features that don't exist in Obtainium at all.
 
 - **💾 Save assets** - Option to save update assets (e.g. APKs) to your chosen folder, during update process itself.
 
----
 
 ## 🔧 Enhanced Features
 
@@ -48,8 +48,6 @@ Features Obtainium has, extended or improved here.
 - **🔖 Active filter chips** — Extends Obtainium's filter with dismissible chips pinned below the toolbar showing every active non-text filter (category, pinned, installed state, etc.). Tap any chip to clear just that filter. The row disappears entirely when nothing is active.
 
 - **🏷️ Category customization** — More control over your categories: instead of cycling between a few random colors, choose from a 5×12 color palette (vivid to pastel), or enter the hex value yourself. A live preview of the category chip as you name and color it. Category colors are WYSIWYG. Category's name switches between black and white text automatically for readability. You can also rename an existing category, and all assigned apps automatically receive it. 
-
----
 
 ## 🎨 UI & UX
 

--- a/lib/app_sources/apkmirror.dart
+++ b/lib/app_sources/apkmirror.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:easy_localization/easy_localization.dart';
+import 'package:html/dom.dart' as html_dom;
 import 'package:html/parser.dart';
 import 'package:http/http.dart';
 import 'package:obtainium/components/generated_form.dart';
@@ -12,7 +13,20 @@ import 'package:obtainium/providers/source_provider.dart';
 /// Image and static asset URL suffixes that appear in page HTML after a string
 /// that looks like `com.vendor.app`, e.g. `com.google.android.calendar.png`.
 const _apkMirrorTrailingNonPackageSegments = <String>{
-  'avif', 'bmp', 'gif', 'ico', 'jpeg', 'jpg', 'png', 'svg', 'webp',
+  'avif',
+  'bmp',
+  'gif',
+  'ico',
+  'jpeg',
+  'jpg',
+  'png',
+  'svg',
+  'webp',
+};
+
+const _apkMirrorCanonicalAppSlugByAlias = <String, String>{
+  'youtube-music-android-automotive': 'youtube-music',
+  'youtube-music-wear-os': 'youtube-music',
 };
 
 String _apkMirrorNormalizeInferredPackageCandidate(String rawCandidate) {
@@ -68,7 +82,10 @@ String? releaseUrlFromApkMirrorRssItemInner(String itemInnerXml) {
 
 /// When [itemInnerBlocks] is empty, HTML-parsed item index still matches the
 /// Nth `<item>...</item>` region in raw XML for link extraction.
-String? releaseUrlFromApkMirrorFeedBodyForItemIndex(String body, int itemIndex) {
+String? releaseUrlFromApkMirrorFeedBodyForItemIndex(
+  String body,
+  int itemIndex,
+) {
   if (itemIndex < 0) return null;
   final segments = body.split(RegExp(r'<item\b[^>]*>', caseSensitive: false));
   if (itemIndex + 1 >= segments.length) return null;
@@ -101,13 +118,125 @@ String? iconUrlFromApkMirrorAppPageHtml(String html, String pageUrl) {
   final doc = parse(html);
   String? raw =
       doc.querySelector('meta[property="og:image"]')?.attributes['content'] ??
-          doc.querySelector('meta[name="twitter:image"]')?.attributes['content'] ??
-          doc
-              .querySelector('meta[name="twitter:image:src"]')
-              ?.attributes['content'];
+      doc.querySelector('meta[name="twitter:image"]')?.attributes['content'] ??
+      doc
+          .querySelector('meta[name="twitter:image:src"]')
+          ?.attributes['content'];
   if (raw == null || raw.trim().isEmpty) return null;
   final baseUri = Uri.parse(pageUrl);
   return baseUri.resolveUri(Uri.parse(raw.trim())).toString();
+}
+
+int? apkSizeBytesFromApkMirrorSizeText(String sizeText) {
+  final match = RegExp(
+    r'([0-9]+(?:\.[0-9]+)?)\s*(B|KB|MB|GB)',
+    caseSensitive: false,
+  ).firstMatch(sizeText);
+  if (match == null) {
+    return null;
+  }
+  final double? sizeNumber = double.tryParse(match.group(1)!);
+  if (sizeNumber == null) {
+    return null;
+  }
+  final String unit = match.group(2)!.toUpperCase();
+  double multiplier = 1;
+  if (unit == 'KB') {
+    multiplier = 1024;
+  } else if (unit == 'MB') {
+    multiplier = 1024 * 1024;
+  } else if (unit == 'GB') {
+    multiplier = 1024 * 1024 * 1024;
+  }
+  return (sizeNumber * multiplier).round();
+}
+
+int? apkSizeBytesFromApkMirrorReleasePageHtml(String html) {
+  final pageText = parse(html).body?.text ?? html;
+  final directDownloadSizeTexts = RegExp(
+    r'Download[^\n]*,\s*([0-9]+(?:\.[0-9]+)?)\s*(B|KB|MB|GB)',
+    caseSensitive: false,
+  ).allMatches(pageText).map((match) => match.group(0)!).toSet().toList();
+  if (directDownloadSizeTexts.length == 1) {
+    return apkSizeBytesFromApkMirrorSizeText(directDownloadSizeTexts.single);
+  }
+
+  final fileSizeTexts = RegExp(
+    r'File size:\s*([0-9]+(?:\.[0-9]+)?)\s*(B|KB|MB|GB)',
+    caseSensitive: false,
+  ).allMatches(pageText).map((match) => match.group(0)!).toSet().toList();
+  if (fileSizeTexts.length == 1) {
+    return apkSizeBytesFromApkMirrorSizeText(fileSizeTexts.single);
+  }
+  return null;
+}
+
+String? _apkMirrorSameReleaseDownloadPageUrlFromElement(
+  html_dom.Element linkElement,
+  String releasePageUrl,
+) {
+  final href = linkElement.attributes['href']?.trim();
+  if (href == null || href.isEmpty) {
+    return null;
+  }
+  final releaseUri = Uri.parse(releasePageUrl);
+  final resolved = releaseUri.resolve(href).toString();
+  final releasePrefix = releasePageUrl.endsWith('/')
+      ? releasePageUrl
+      : '$releasePageUrl/';
+  if (!resolved.startsWith(releasePrefix)) {
+    return null;
+  }
+  final resolvedPath = Uri.parse(resolved).path;
+  if (!resolvedPath.endsWith('-apk-download/') &&
+      !resolvedPath.endsWith('-apk-download')) {
+    return null;
+  }
+  return resolved.endsWith('/') ? resolved : '$resolved/';
+}
+
+List<String> apkMirrorDownloadPageUrlsFromReleasePageHtml(
+  String html,
+  String releasePageUrl,
+) {
+  final doc = parse(html);
+  final Map<String, int> weightedUrls = {};
+  for (final linkElement in doc.querySelectorAll('a[href]')) {
+    final resolved = _apkMirrorSameReleaseDownloadPageUrlFromElement(
+      linkElement,
+      releasePageUrl,
+    );
+    if (resolved == null) {
+      continue;
+    }
+    var parentText = linkElement.text;
+    html_dom.Element? parent = linkElement.parent;
+    for (int depth = 0; depth < 4 && parent != null; depth++) {
+      parentText = '$parentText ${parent.text}';
+      parent = parent.parent;
+    }
+    final normalizedParentText = parentText.replaceAll(RegExp(r'\s+'), ' ');
+    var weight = 50;
+    if (RegExp(r'(^|\s)APK(\s|$)').hasMatch(normalizedParentText)) {
+      weight -= 20;
+    }
+    if (RegExp(r'(^|\s)BUNDLE(\s|$)').hasMatch(normalizedParentText)) {
+      weight += 20;
+    }
+    final existingWeight = weightedUrls[resolved];
+    if (existingWeight == null || weight < existingWeight) {
+      weightedUrls[resolved] = weight;
+    }
+  }
+  final sortedEntries = weightedUrls.entries.toList()
+    ..sort((left, right) {
+      final weightCompare = left.value.compareTo(right.value);
+      if (weightCompare != 0) {
+        return weightCompare;
+      }
+      return left.key.compareTo(right.key);
+    });
+  return sortedEntries.map((entry) => entry.key).toList();
 }
 
 DateTime? releaseDateFromApkMirrorRssItemInner(String itemInnerXml) {
@@ -129,7 +258,6 @@ DateTime? releaseDateFromApkMirrorRssItemInner(String itemInnerXml) {
   }
   return null;
 }
-
 
 class APKMirror extends AppSource {
   APKMirror() {
@@ -183,7 +311,18 @@ class APKMirror extends AppSource {
     if (match == null) {
       throw InvalidURLError(name);
     }
-    return match.group(0)!;
+    final standardizedUrl = match.group(0)!;
+    final lowerStandardizedUrl = standardizedUrl.toLowerCase();
+    for (final aliasEntry in _apkMirrorCanonicalAppSlugByAlias.entries) {
+      if (lowerStandardizedUrl.endsWith('/${aliasEntry.key}')) {
+        return standardizedUrl.substring(
+              0,
+              standardizedUrl.length - aliasEntry.key.length,
+            ) +
+            aliasEntry.value;
+      }
+    }
+    return standardizedUrl;
   }
 
   @override
@@ -258,15 +397,24 @@ class APKMirror extends AppSource {
       DateTime? releaseDate;
 
       if (itemInnerBlocks.isNotEmpty) {
-        for (int scanIndex = 0; scanIndex < itemInnerBlocks.length; scanIndex++) {
+        for (
+          int scanIndex = 0;
+          scanIndex < itemInnerBlocks.length;
+          scanIndex++
+        ) {
           collectReleaseTitleCandidate(
             titleFromApkMirrorRssItemInner(itemInnerBlocks[scanIndex]),
           );
         }
-        final RegExp? titleFilterPattern =
-            regexFilter != null ? RegExp(regexFilter) : null;
+        final RegExp? titleFilterPattern = regexFilter != null
+            ? RegExp(regexFilter)
+            : null;
         String? chosenBlock;
-        for (int itemIndex = 0; itemIndex < itemInnerBlocks.length; itemIndex++) {
+        for (
+          int itemIndex = 0;
+          itemIndex < itemInnerBlocks.length;
+          itemIndex++
+        ) {
           if (!fallbackToOlderReleases && itemIndex > 0) break;
           final block = itemInnerBlocks[itemIndex];
           final nameToFilter = titleFromApkMirrorRssItemInner(block);
@@ -294,8 +442,9 @@ class APKMirror extends AppSource {
         int chosenParsedItemIndex = -1;
         for (int itemIndex = 0; itemIndex < parsedItems.length; itemIndex++) {
           if (!fallbackToOlderReleases && itemIndex > 0) break;
-          final nameToFilter =
-              parsedItems[itemIndex].querySelector('title')?.innerHtml;
+          final nameToFilter = parsedItems[itemIndex]
+              .querySelector('title')
+              ?.innerHtml;
           if (regexFilter != null &&
               nameToFilter != null &&
               !RegExp(regexFilter).hasMatch(nameToFilter.trim())) {
@@ -322,6 +471,10 @@ class APKMirror extends AppSource {
           );
         }
       }
+      if (releasePageUrl != null &&
+          !releasePageUrl.startsWith('$standardUrl/')) {
+        releasePageUrl = null;
+      }
       String? version = titleString
           ?.substring(
             RegExp('[0-9]').firstMatch(titleString)?.start ?? 0,
@@ -333,6 +486,46 @@ class APKMirror extends AppSource {
       }
       if (version == null || version.isEmpty) {
         throw NoVersionError();
+      }
+
+      int? apkSizeBytes;
+      String? downloadPageUrl;
+      if (releasePageUrl != null) {
+        try {
+          final releasePageResponse = await sourceRequest(
+            releasePageUrl,
+            additionalSettings,
+          );
+          if (releasePageResponse.statusCode == 200) {
+            apkSizeBytes = apkSizeBytesFromApkMirrorReleasePageHtml(
+              releasePageResponse.body,
+            );
+            final downloadPageUrls =
+                apkMirrorDownloadPageUrlsFromReleasePageHtml(
+                  releasePageResponse.body,
+                  releasePageUrl,
+                );
+            for (final candidateDownloadPageUrl in downloadPageUrls) {
+              final downloadPageResponse = await sourceRequest(
+                candidateDownloadPageUrl,
+                additionalSettings,
+              );
+              if (downloadPageResponse.statusCode != 200) {
+                continue;
+              }
+              final candidateSize = apkSizeBytesFromApkMirrorReleasePageHtml(
+                downloadPageResponse.body,
+              );
+              if (candidateSize != null) {
+                apkSizeBytes = candidateSize;
+                downloadPageUrl = candidateDownloadPageUrl;
+                break;
+              }
+            }
+          }
+        } catch (_) {
+          // Size is optional; keep track-only update checks resilient.
+        }
       }
 
       // Fetch icon from the app's main listing page (optional).
@@ -351,9 +544,10 @@ class APKMirror extends AppSource {
         [],
         getAppNames(standardUrl),
         releaseDate: releaseDate,
-        changeLog: releasePageUrl,
+        changeLog: downloadPageUrl ?? releasePageUrl,
         iconUrl: iconUrl,
         rawReleaseTitleCandidates: rawReleaseTitleCandidates,
+        apkSizeBytes: apkSizeBytes,
       );
     } else {
       throw getObtainiumHttpError(res);

--- a/lib/app_sources/apkpure.dart
+++ b/lib/app_sources/apkpure.dart
@@ -81,12 +81,14 @@ class APKPure extends AppSource {
     List<String> supportedArchs,
     Map<String, dynamic> additionalSettings,
   ) async {
+    final Map<String, int> sizeByName = {};
     var apkUrls = versionVariants
-        .map((e) {
-          String appId = e['package_name'];
-          String versionCode = e['version_code'];
+        .map((versionVariant) {
+          String appId = versionVariant['package_name'];
+          String versionCode = versionVariant['version_code'];
 
-          List<String> architectures = e['native_code']?.cast<String>();
+          List<String> architectures = versionVariant['native_code']
+              ?.cast<String>();
           String architectureString = architectures.join(',');
           if (architectures.contains("universal") ||
               architectures.contains("unlimited")) {
@@ -98,13 +100,20 @@ class APKPure extends AppSource {
             return null;
           }
 
-          String type = e['asset']['type'];
-          String downloadUri = e['asset']['url'];
+          final asset = versionVariant['asset'];
+          String type = asset['type'];
+          String downloadUri = asset['url'];
+          final apkName =
+              '$appId-$versionCode-$architectureString.${type.toLowerCase()}';
+          final rawSize = asset['size'];
+          final int? parsedSize = rawSize is num
+              ? rawSize.toInt()
+              : int.tryParse(rawSize?.toString() ?? '');
+          if (parsedSize != null) {
+            sizeByName[apkName] = parsedSize;
+          }
 
-          return MapEntry(
-            '$appId-$versionCode-$architectureString.${type.toLowerCase()}',
-            downloadUri,
-          );
+          return MapEntry(apkName, downloadUri);
         })
         .nonNulls
         .toList()
@@ -128,6 +137,29 @@ class APKPure extends AppSource {
     if (additionalSettings['useFirstApkOfVersion'] == true) {
       apkUrls = [apkUrls.first];
     }
+    int? apkSizeBytes = apkUrls.isNotEmpty
+        ? sizeByName[apkUrls.last.key]
+        : null;
+    if (apkUrls.isNotEmpty) {
+      try {
+        final responseWithClient = await sourceRequestStreamResponse(
+          'HEAD',
+          apkUrls.last.value,
+          null,
+          additionalSettings,
+        );
+        final headResponse = responseWithClient.value.value;
+        final contentLength = headResponse.contentLength;
+        if (headResponse.statusCode >= 200 &&
+            headResponse.statusCode < 300 &&
+            contentLength >= 0) {
+          apkSizeBytes = contentLength;
+        }
+        responseWithClient.value.key.close();
+      } catch (_) {
+        // APKPure's API size is a fallback when the CDN does not report length.
+      }
+    }
 
     return APKDetails(
       version,
@@ -135,6 +167,7 @@ class APKPure extends AppSource {
       AppNames(author, appName),
       releaseDate: releaseDate,
       changeLog: changeLog,
+      apkSizeBytes: apkSizeBytes,
     );
   }
 

--- a/lib/app_sources/aptoide.dart
+++ b/lib/app_sources/aptoide.dart
@@ -73,6 +73,10 @@ class Aptoide extends AppSource {
     String? dateStr = appDetails['updated'];
     String? version = appDetails['file']?['vername'];
     String? apkUrl = appDetails['file']?['path'];
+    final rawSize = appDetails['file']?['filesize'] ?? appDetails['size'];
+    final int? apkSizeBytes = rawSize is num
+        ? rawSize.toInt()
+        : int.tryParse(rawSize?.toString() ?? '');
     if (version == null) {
       throw NoVersionError();
     }
@@ -89,6 +93,7 @@ class Aptoide extends AppSource {
       getApkUrlsFromUrls([apkUrl]),
       AppNames(author, appName),
       releaseDate: relDate,
+      apkSizeBytes: apkSizeBytes,
     );
   }
 }

--- a/lib/app_sources/fdroid.dart
+++ b/lib/app_sources/fdroid.dart
@@ -223,8 +223,8 @@ class FDroid extends AppSource {
       if (trySelectingSuggestedVersionCode &&
           response['suggestedVersionCode'] != null &&
           filterVersionsByRegEx == null) {
-        final String suggestedVersionCodeText =
-            response['suggestedVersionCode'].toString();
+        final String suggestedVersionCodeText = response['suggestedVersionCode']
+            .toString();
         var suggestedReleases = releases.where(
           (element) =>
               element['versionCode'].toString() == suggestedVersionCodeText,
@@ -283,6 +283,33 @@ class FDroid extends AppSource {
       List<String> apkUrls = releaseChoices
           .map((e) => '${apkUrlPrefix}_${e['versionCode']}.apk')
           .toList();
+      final uniqueApkUrls = apkUrls.toSet().toList();
+      int? apkSizeBytes;
+      if (uniqueApkUrls.isNotEmpty) {
+        try {
+          final headers = await getRequestHeaders(
+            additionalSettings,
+            uniqueApkUrls.last,
+            forAPKDownload: true,
+          );
+          final responseWithClient = await sourceRequestStreamResponse(
+            'HEAD',
+            uniqueApkUrls.last,
+            headers,
+            additionalSettings,
+          );
+          final headResponse = responseWithClient.value.value;
+          final contentLength = headResponse.contentLength;
+          if (headResponse.statusCode >= 200 &&
+              headResponse.statusCode < 300 &&
+              contentLength >= 0) {
+            apkSizeBytes = contentLength;
+          }
+          responseWithClient.value.key.close();
+        } catch (_) {
+          // File size is optional; update detection should still succeed.
+        }
+      }
       String? iconUrl;
       final String packageLabel = () {
         final Object? rawPackageName = response['packageName'];
@@ -292,8 +319,9 @@ class FDroid extends AppSource {
             return trimmedPackageName;
           }
         }
-        final String? queryAppId =
-            Uri.parse(standardUrl).queryParameters['appId']?.trim();
+        final String? queryAppId = Uri.parse(
+          standardUrl,
+        ).queryParameters['appId']?.trim();
         if (queryAppId != null && queryAppId.isNotEmpty) {
           return queryAppId;
         }
@@ -323,9 +351,10 @@ class FDroid extends AppSource {
       }
       return APKDetails(
         version,
-        getApkUrlsFromUrls(apkUrls.toSet().toList()),
+        getApkUrlsFromUrls(uniqueApkUrls),
         AppNames(sourceName, packageLabel),
         iconUrl: iconUrl,
+        apkSizeBytes: apkSizeBytes,
       );
     } else {
       throw getObtainiumHttpError(res);

--- a/lib/app_sources/fdroid.dart
+++ b/lib/app_sources/fdroid.dart
@@ -238,11 +238,12 @@ class FDroid extends AppSource {
       if (filterVersionsByRegEx?.isNotEmpty == true) {
         version = null;
         releaseChoices = [];
-        for (var i = 0; i < releases.length; i++) {
+        for (final release in releases) {
           if (RegExp(
             filterVersionsByRegEx!,
-          ).hasMatch(releases[i]['versionName']?.toString() ?? '')) {
-            version = releases[i]['versionName']?.toString();
+          ).hasMatch(release['versionName']?.toString() ?? '')) {
+            version = release['versionName']?.toString();
+            break;
           }
         }
         if (version == null) {

--- a/lib/app_sources/fdroidrepo.dart
+++ b/lib/app_sources/fdroidrepo.dart
@@ -11,7 +11,7 @@ import 'package:obtainium/providers/source_provider.dart';
 /// [IzzyOnDroid] must not use a bare [FDroidRepo] instance for network calls).
 Future<Response> fdroidRepoRequestIndexWithVariants(
   Future<Response> Function(String url, Map<String, dynamic> settings)
-      doSourceRequest,
+  doSourceRequest,
   String normalizedRepoBaseUrl,
   Map<String, dynamic> additionalSettings,
 ) async {
@@ -149,7 +149,8 @@ class FDroidRepo extends AppSource {
     if (foundApps.isEmpty) {
       throw ObtainiumError(tr('appWithIdOrNameNotFound'));
     }
-    var authorName = body.querySelector('repo')?.attributes['name'] ?? authorFallback;
+    var authorName =
+        body.querySelector('repo')?.attributes['name'] ?? authorFallback;
     String appId = foundApps[0].attributes['id']!;
     foundApps[0].querySelector('name')?.innerHtml ?? appId;
     var appName = foundApps[0].querySelector('name')?.innerHtml ?? appId;
@@ -162,7 +163,9 @@ class FDroidRepo extends AppSource {
     if (latestVersion == null) {
       throw NoVersionError();
     }
-    String? marketvercodeStr = foundApps[0].querySelector('marketvercode')?.innerHtml;
+    String? marketvercodeStr = foundApps[0]
+        .querySelector('marketvercode')
+        ?.innerHtml;
     int? marketvercode = int.tryParse(marketvercodeStr ?? '');
     List selectedReleases = [];
     final bool trySelectingSuggestedVersionCode =
@@ -171,43 +174,59 @@ class FDroidRepo extends AppSource {
         additionalSettings['pickHighestVersionCode'] == true ||
         additionalSettings['autoSelectHighestVersionCode'] == true;
     if (trySelectingSuggestedVersionCode && marketvercode != null) {
-      selectedReleases = releases.where((e) =>
-        int.tryParse(e.querySelector('versioncode')?.innerHtml ?? '') == marketvercode &&
-        e.querySelector('apkname') != null
-      ).toList();
+      selectedReleases = releases
+          .where(
+            (e) =>
+                int.tryParse(e.querySelector('versioncode')?.innerHtml ?? '') ==
+                    marketvercode &&
+                e.querySelector('apkname') != null,
+          )
+          .toList();
     }
     String? appAuthorName = foundApps[0].querySelector('author')?.innerHtml;
     if (appAuthorName != null) {
       authorName = appAuthorName;
     }
     if (selectedReleases.isEmpty) {
-      selectedReleases = releases.where((e) =>
-        e.querySelector('version')?.innerHtml == latestVersion &&
-        e.querySelector('apkname') != null
-      ).toList();
+      selectedReleases = releases
+          .where(
+            (e) =>
+                e.querySelector('version')?.innerHtml == latestVersion &&
+                e.querySelector('apkname') != null,
+          )
+          .toList();
       if (selectedReleases.length > 1 && pickHighestVersionCode) {
         selectedReleases.sort((e1, e2) {
-          return int.parse(e2.querySelector('versioncode')!.innerHtml).compareTo(
-            int.parse(e1.querySelector('versioncode')!.innerHtml),
-          );
+          return int.parse(
+            e2.querySelector('versioncode')!.innerHtml,
+          ).compareTo(int.parse(e1.querySelector('versioncode')!.innerHtml));
         });
         selectedReleases = [selectedReleases[0]];
       }
     }
-    String? selectedVersion = selectedReleases[0].querySelector('version')?.innerHtml;
+    String? selectedVersion = selectedReleases[0]
+        .querySelector('version')
+        ?.innerHtml;
     if (selectedVersion == null) {
       throw NoVersionError();
     }
     String? added = selectedReleases[0].querySelector('added')?.innerHtml;
     DateTime? releaseDate = added != null ? DateTime.parse(added) : null;
-    final repoBase =
-        indexXmlResponse.request!.url.toString().split('/').reversed.toList().sublist(1).reversed.join('/');
+    final repoBase = indexXmlResponse.request!.url
+        .toString()
+        .split('/')
+        .reversed
+        .toList()
+        .sublist(1)
+        .reversed
+        .join('/');
     List<String> apkUrls = selectedReleases
-        .map(
-          (e) =>
-              '$repoBase/${e.querySelector('apkname')!.innerHtml}',
-        )
+        .map((e) => '$repoBase/${e.querySelector('apkname')!.innerHtml}')
         .toList();
+    final String? apkSizeText = selectedReleases.isNotEmpty
+        ? selectedReleases.last.querySelector('size')?.innerHtml
+        : null;
+    final int? apkSizeBytes = int.tryParse(apkSizeText ?? '');
     String? iconFile = foundApps[0].querySelector('icon')?.innerHtml.trim();
     String? iconUrl;
     if (iconFile != null && iconFile.isNotEmpty) {
@@ -220,6 +239,7 @@ class FDroidRepo extends AppSource {
       releaseDate: releaseDate,
       changeLog: changeLog,
       iconUrl: iconUrl,
+      apkSizeBytes: apkSizeBytes,
     );
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -413,6 +413,9 @@ class _ObtainiumState extends State<Obtainium> {
                   : darkColorScheme;
 
           NavigationBarThemeData navigationBarThemeFor(ColorScheme scheme) {
+            // Use labelMedium as base so nav labels keep M3 size (bare color-only TextStyle inherits body scale and can wrap).
+            final TextStyle navLabelBase =
+                Theme.of(context).textTheme.labelMedium!;
             return NavigationBarThemeData(
               backgroundColor: scheme.surface,
               surfaceTintColor: Colors.transparent,
@@ -428,13 +431,20 @@ class _ObtainiumState extends State<Obtainium> {
               labelTextStyle: WidgetStateProperty.resolveWith((
                 Set<WidgetState> states,
               ) {
+                if (states.contains(WidgetState.disabled)) {
+                  return navLabelBase.copyWith(
+                    color: scheme.onSurfaceVariant.withValues(alpha: 0.38),
+                  );
+                }
                 if (states.contains(WidgetState.selected)) {
-                  return TextStyle(
+                  return navLabelBase.copyWith(
                     color: scheme.primary,
                     fontWeight: FontWeight.w600,
                   );
                 }
-                return TextStyle(color: scheme.onSurfaceVariant);
+                return navLabelBase.copyWith(
+                  color: scheme.onSurfaceVariant,
+                );
               }),
             );
           }

--- a/lib/pages/app.dart
+++ b/lib/pages/app.dart
@@ -75,7 +75,8 @@ String? _resolveStoreUrl({
   // Key absent means this store was never explicitly checked for this app
   // (either no scan at all, or a different store's check ran first).
   // In both cases show the fallback URL — don't suppress unverified stores.
-  if (storeData == null || !storeData.containsKey(storeName)) return fallbackUrl;
+  if (storeData == null || !storeData.containsKey(storeName))
+    return fallbackUrl;
   final entry = storeData[storeName]!;
   if (entry.isEmpty) return null; // confirmed absent (empty string sentinel)
   return entry; // confirmed present
@@ -96,10 +97,11 @@ Future<String?> _checkPlayStoreAvailability(String packageId) async {
     );
     final request = await client.headUrl(uri);
     request.followRedirects = false;
-    request.headers.set(HttpHeaders.userAgentHeader,
-        'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36');
-    final response =
-        await request.close().timeout(const Duration(seconds: 10));
+    request.headers.set(
+      HttpHeaders.userAgentHeader,
+      'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36',
+    );
+    final response = await request.close().timeout(const Duration(seconds: 10));
     await response.drain<void>();
     client.close();
     if (response.statusCode == 200) {
@@ -201,8 +203,10 @@ class AppPage extends StatefulWidget {
 
   final String appId;
   final bool showOppositeOfPreferredView;
+
   /// Folder id when opened from [AppsPage] with [AppsPage.folderId]; matches list [Hero] tags.
   final String? appsListHeroFolderId;
+
   /// When true (e.g. swipe-to-edit), enter inline edit mode once the app is loaded.
   final bool openInEditMode;
 
@@ -277,8 +281,9 @@ class _AppPageState extends State<AppPage> {
       _lastWebViewSurfaceColorApplied = null;
       _scheduledOpenInEditMode = false;
       _clearEditIconStaging();
-      _storeAvailabilityCacheFuture =
-          BulkScanCache.load().then((cache) => cache[widget.appId]);
+      _storeAvailabilityCacheFuture = BulkScanCache.load().then(
+        (cache) => cache[widget.appId],
+      );
     } else if (oldWidget.openInEditMode != widget.openInEditMode) {
       _scheduledOpenInEditMode = false;
     }
@@ -314,7 +319,9 @@ class _AppPageState extends State<AppPage> {
     _editBaselinePackage = _packageController.text;
     _editBaselineNotes = _notesController.text;
     _editBaselineCategories = List<String>.from(_editCategories);
-    _editBaselineIconFingerprint = _iconFingerprintForEditBaseline(appData.icon);
+    _editBaselineIconFingerprint = _iconFingerprintForEditBaseline(
+      appData.icon,
+    );
   }
 
   void _clearEditIconStaging() {
@@ -401,8 +408,10 @@ class _AppPageState extends State<AppPage> {
       _exitEditWithoutSaving();
       return;
     }
-    final _UnsavedAction? action =
-        await _showUnsavedChangesDialog(actionContext, dialogTheme);
+    final _UnsavedAction? action = await _showUnsavedChangesDialog(
+      actionContext,
+      dialogTheme,
+    );
 
     if (!actionContext.mounted || appData == null) return;
 
@@ -411,8 +420,10 @@ class _AppPageState extends State<AppPage> {
         _exitEditWithoutSaving();
         break;
       case _UnsavedAction.saveAndExit:
-        final appsProvider =
-            Provider.of<AppsProvider>(actionContext, listen: false);
+        final appsProvider = Provider.of<AppsProvider>(
+          actionContext,
+          listen: false,
+        );
         await _saveEdit(appData, appsProvider);
         break;
       case _UnsavedAction.keepEditing:
@@ -442,10 +453,10 @@ class _AppPageState extends State<AppPage> {
             onPressed: updating
                 ? null
                 : () => _onCancelEditPressed(
-                      themeContext,
-                      appData,
-                      pageThemeForDialogs,
-                    ),
+                    themeContext,
+                    appData,
+                    pageThemeForDialogs,
+                  ),
             child: const Icon(Icons.close),
           ),
           const SizedBox(height: 12),
@@ -467,21 +478,22 @@ class _AppPageState extends State<AppPage> {
     _nameController.text = appData.name;
     _authorController.text = appData.author;
     final dynamic aboutRaw = appData.app.additionalSettings['about'];
-    _notesController.text =
-        aboutRaw is String ? aboutRaw : (aboutRaw?.toString() ?? '');
+    _notesController.text = aboutRaw is String
+        ? aboutRaw
+        : (aboutRaw?.toString() ?? '');
     _urlController.text = appData.app.url;
     _packageController.text = appData.app.id;
     _editCategories = List<String>.from(appData.app.categories);
-    _editBaselineHadUserOverride =
-        appsProvider.hasUserAppIconOverride(widget.appId);
+    _editBaselineHadUserOverride = appsProvider.hasUserAppIconOverride(
+      widget.appId,
+    );
     _captureEditBaseline(appData);
     setState(() => _editMode = true);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       void placeCaretAtEnd(TextEditingController controller) {
         final String text = controller.text;
-        controller.selection =
-            TextSelection.collapsed(offset: text.length);
+        controller.selection = TextSelection.collapsed(offset: text.length);
       }
 
       placeCaretAtEnd(_nameController);
@@ -582,8 +594,9 @@ class _AppPageState extends State<AppPage> {
     // session, all we need to do is null out the staged icon bytes.
     if (appsProvider.hasUserAppIconOverride(widget.appId)) {
       shouldClearOverride = true;
-      preview =
-          await appsProvider.loadIconPreviewExcludingUserOverride(widget.appId);
+      preview = await appsProvider.loadIconPreviewExcludingUserOverride(
+        widget.appId,
+      );
     }
 
     if (!mounted) return;
@@ -596,7 +609,8 @@ class _AppPageState extends State<AppPage> {
   }
 
   void _openIconWebSearch(AppInMemory appData) {
-    final String query = '${appData.name} square app icon transparent background';
+    final String query =
+        '${appData.name} square app icon transparent background';
     launchUrlString(
       'https://images.google.com/search?tbm=isch&q=${Uri.encodeComponent(query)}',
       mode: LaunchMode.externalApplication,
@@ -638,11 +652,7 @@ class _AppPageState extends State<AppPage> {
               clipBehavior: Clip.none,
               children: [
                 bodyColumn,
-                Positioned(
-                  bottom: 0,
-                  right: 0,
-                  child: cardWatermark,
-                ),
+                Positioned(bottom: 0, right: 0, child: cardWatermark),
               ],
             )
           : bodyColumn,
@@ -672,121 +682,104 @@ class _AppPageState extends State<AppPage> {
   ) {
     final bool showResetIconButton =
         appsProvider.hasUserAppIconOverride(widget.appId) ||
-            _editStagedIconBytes != null;
+        _editStagedIconBytes != null;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _materialAppPageSectionCard(
-          ctx,
-          tr('nameAndLinks'),
-          [
-            TextField(
-              controller: _nameController,
-              decoration: appPageOutlinedInputDecoration(
-                ctx,
-                labelText: tr('appName'),
-                isDense: true,
-              ),
-              textCapitalization: TextCapitalization.words,
+        _materialAppPageSectionCard(ctx, tr('nameAndLinks'), [
+          TextField(
+            controller: _nameController,
+            decoration: appPageOutlinedInputDecoration(
+              ctx,
+              labelText: tr('appName'),
+              isDense: true,
             ),
-            const SizedBox(height: 12),
-            TextField(
-              controller: _authorController,
-              decoration: appPageOutlinedInputDecoration(
-                ctx,
-                labelText: tr('author'),
-                isDense: true,
-              ),
-              textCapitalization: TextCapitalization.words,
+            textCapitalization: TextCapitalization.words,
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _authorController,
+            decoration: appPageOutlinedInputDecoration(
+              ctx,
+              labelText: tr('author'),
+              isDense: true,
             ),
-            const SizedBox(height: 12),
-            TextField(
-              controller: _packageController,
-              decoration: appPageOutlinedInputDecoration(
-                ctx,
-                labelText: tr('package'),
-                isDense: true,
-              ),
+            textCapitalization: TextCapitalization.words,
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _packageController,
+            decoration: appPageOutlinedInputDecoration(
+              ctx,
+              labelText: tr('package'),
+              isDense: true,
             ),
-            const SizedBox(height: 12),
-            TextField(
-              controller: _urlController,
-              decoration: appPageOutlinedInputDecoration(
-                ctx,
-                labelText: tr('trackedSource'),
-                isDense: true,
-              ),
-              keyboardType: TextInputType.url,
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _urlController,
+            decoration: appPageOutlinedInputDecoration(
+              ctx,
+              labelText: tr('trackedSource'),
+              isDense: true,
             ),
-          ],
-        ),
-        _materialAppPageSectionCard(
-          ctx,
-          tr('appIconActionsTitle'),
-          [
-            Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              crossAxisAlignment: WrapCrossAlignment.center,
-              children: [
-                FilledButton.tonal(
-                  onPressed: () => _pickEditIcon(appsProvider),
-                  child: Text(tr('changeAppIcon')),
-                ),
+            keyboardType: TextInputType.url,
+          ),
+        ]),
+        _materialAppPageSectionCard(ctx, tr('appIconActionsTitle'), [
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              FilledButton.tonal(
+                onPressed: () => _pickEditIcon(appsProvider),
+                child: Text(tr('changeAppIcon')),
+              ),
+              OutlinedButton(
+                onPressed: () => _openIconWebSearch(appData),
+                child: Text(tr('searchWebForAppIcon')),
+              ),
+              if (showResetIconButton)
                 OutlinedButton(
-                  onPressed: () => _openIconWebSearch(appData),
-                  child: Text(tr('searchWebForAppIcon')),
+                  onPressed: updating
+                      ? null
+                      : () => _onResetEditIconPressed(appsProvider),
+                  child: Text(tr('resetAppIcon')),
                 ),
-                if (showResetIconButton)
-                  OutlinedButton(
-                    onPressed: updating
-                        ? null
-                        : () => _onResetEditIconPressed(appsProvider),
-                    child: Text(tr('resetAppIcon')),
-                  ),
-              ],
-            ),
-          ],
-        ),
-        _materialAppPageSectionCard(
-          ctx,
-          tr('categories'),
-          [
-            CategoryEditorSelector(
-              key: ValueKey<String>('app_categories_${widget.appId}'),
-              preselected: _editCategories.toSet(),
-              alignment: WrapAlignment.start,
-              showLabelWhenNotEmpty: false,
-              onSelected: (cats) =>
-                  setState(() => _editCategories = cats),
-            ),
-          ],
-        ),
-        KeyedSubtree(
-          key: _notesEditSectionKey,
-          child: _materialAppPageSectionCard(
-            ctx,
-            tr('notes'),
-            [
-              TextField(
-                controller: _notesController,
-                focusNode: _notesEditFocusNode,
-                scrollPadding: const EdgeInsets.only(bottom: 160),
-                decoration: appPageOutlinedInputDecoration(
-                  ctx,
-                  labelText: null,
-                  hintText: tr('notes'),
-                  isDense: true,
-                ),
-                keyboardType: TextInputType.multiline,
-                textInputAction: TextInputAction.newline,
-                minLines: 3,
-                maxLines: 8,
-                textCapitalization: TextCapitalization.sentences,
-              ),
             ],
           ),
+        ]),
+        _materialAppPageSectionCard(ctx, tr('categories'), [
+          CategoryEditorSelector(
+            key: ValueKey<String>('app_categories_${widget.appId}'),
+            preselected: _editCategories.toSet(),
+            alignment: WrapAlignment.start,
+            showLabelWhenNotEmpty: false,
+            onSelected: (cats) => setState(() => _editCategories = cats),
+          ),
+        ]),
+        KeyedSubtree(
+          key: _notesEditSectionKey,
+          child: _materialAppPageSectionCard(ctx, tr('notes'), [
+            TextField(
+              controller: _notesController,
+              focusNode: _notesEditFocusNode,
+              scrollPadding: const EdgeInsets.only(bottom: 160),
+              decoration: appPageOutlinedInputDecoration(
+                ctx,
+                labelText: null,
+                hintText: tr('notes'),
+                isDense: true,
+              ),
+              keyboardType: TextInputType.multiline,
+              textInputAction: TextInputAction.newline,
+              minLines: 3,
+              maxLines: 8,
+              textCapitalization: TextCapitalization.sentences,
+            ),
+          ]),
         ),
       ],
     );
@@ -1025,36 +1018,34 @@ class _AppPageState extends State<AppPage> {
         ),
       );
     } else {
-      iconChild = GestureDetector(
-        onTap: onTap,
-        child: emptyPlaceholder,
-      );
+      iconChild = GestureDetector(onTap: onTap, child: emptyPlaceholder);
     }
     if (heroTag != null) {
       return Hero(
         tag: heroTag,
-        flightShuttleBuilder: (
-          BuildContext flightContext,
-          Animation<double> animation,
-          HeroFlightDirection flightDirection,
-          BuildContext fromHeroContext,
-          BuildContext toHeroContext,
-        ) {
-          final Uint8List? shuttleBytes = bytesForImage;
-          if (shuttleBytes != null) {
-            return ClipRRect(
-              borderRadius: BorderRadius.circular(borderRadius),
-              child: Image.memory(
-                shuttleBytes,
-                height: size,
-                width: size,
-                fit: BoxFit.cover,
-                gaplessPlayback: true,
-              ),
-            );
-          }
-          return emptyPlaceholder;
-        },
+        flightShuttleBuilder:
+            (
+              BuildContext flightContext,
+              Animation<double> animation,
+              HeroFlightDirection flightDirection,
+              BuildContext fromHeroContext,
+              BuildContext toHeroContext,
+            ) {
+              final Uint8List? shuttleBytes = bytesForImage;
+              if (shuttleBytes != null) {
+                return ClipRRect(
+                  borderRadius: BorderRadius.circular(borderRadius),
+                  child: Image.memory(
+                    shuttleBytes,
+                    height: size,
+                    width: size,
+                    fit: BoxFit.cover,
+                    gaplessPlayback: true,
+                  ),
+                );
+              }
+              return emptyPlaceholder;
+            },
         child: iconChild,
       );
     }
@@ -1110,8 +1101,9 @@ class _AppPageState extends State<AppPage> {
   @override
   void initState() {
     super.initState();
-    _storeAvailabilityCacheFuture =
-        BulkScanCache.load().then((cache) => cache[widget.appId]);
+    _storeAvailabilityCacheFuture = BulkScanCache.load().then(
+      (cache) => cache[widget.appId],
+    );
     _notesEditFocusNode.addListener(() {
       if (!_notesEditFocusNode.hasFocus || !mounted) return;
       void scrollNotesIntoView() {
@@ -1129,7 +1121,10 @@ class _AppPageState extends State<AppPage> {
 
       WidgetsBinding.instance.addPostFrameCallback((_) {
         scrollNotesIntoView();
-        Future<void>.delayed(const Duration(milliseconds: 120), scrollNotesIntoView);
+        Future<void>.delayed(
+          const Duration(milliseconds: 120),
+          scrollNotesIntoView,
+        );
       });
     });
     _webViewController = WebViewController()
@@ -1163,8 +1158,10 @@ class _AppPageState extends State<AppPage> {
     final pid = widget.appId;
     if (pid.isEmpty) return;
 
-    final trackedUrl =
-        Provider.of<AppsProvider>(context, listen: false).apps[pid]?.app.url;
+    final trackedUrl = Provider.of<AppsProvider>(
+      context,
+      listen: false,
+    ).apps[pid]?.app.url;
 
     final cache = await BulkScanCache.load();
     final storeData = cache[pid] ?? {};
@@ -1173,23 +1170,35 @@ class _AppPageState extends State<AppPage> {
 
     if (!_trackedUrlIsFromHost(trackedUrl, 'apkmirror.com') &&
         !storeData.containsKey('APKMirror')) {
-      futures.add(BulkImportService.checkApkMirror([pid])
-          .then((r) => MapEntry('APKMirror', r[pid])));
+      futures.add(
+        BulkImportService.checkApkMirror([
+          pid,
+        ]).then((r) => MapEntry('APKMirror', r[pid])),
+      );
     }
     if (!_trackedUrlIsFromHost(trackedUrl, 'f-droid.org') &&
         !storeData.containsKey('F-Droid')) {
-      futures.add(BulkImportService.checkFDroid([pid])
-          .then((r) => MapEntry('F-Droid', r[pid])));
+      futures.add(
+        BulkImportService.checkFDroid([
+          pid,
+        ]).then((r) => MapEntry('F-Droid', r[pid])),
+      );
     }
     if (!_trackedUrlIsFromHost(trackedUrl, 'apkpure.') &&
         !storeData.containsKey('APKPure')) {
-      futures.add(BulkImportService.checkApkPure([pid])
-          .then((r) => MapEntry('APKPure', r[pid])));
+      futures.add(
+        BulkImportService.checkApkPure([
+          pid,
+        ]).then((r) => MapEntry('APKPure', r[pid])),
+      );
     }
     if (!_trackedUrlIsFromHost(trackedUrl, 'play.google.com') &&
         !storeData.containsKey('PlayStore')) {
-      futures.add(_checkPlayStoreAvailability(pid)
-          .then((url) => MapEntry('PlayStore', url)));
+      futures.add(
+        _checkPlayStoreAvailability(
+          pid,
+        ).then((url) => MapEntry('PlayStore', url)),
+      );
     }
 
     if (futures.isEmpty) return;
@@ -1210,8 +1219,10 @@ class _AppPageState extends State<AppPage> {
   }
 
   Future<void> _runCheckUpdate(String id, {bool resetVersion = false}) async {
-    final AppsProvider appsProvider =
-        Provider.of<AppsProvider>(context, listen: false);
+    final AppsProvider appsProvider = Provider.of<AppsProvider>(
+      context,
+      listen: false,
+    );
     try {
       setState(() {
         updating = true;
@@ -1225,8 +1236,9 @@ class _AppPageState extends State<AppPage> {
       // while this page was already open in the navigation stack.
       setState(() {
         _requestedMissingIconLoad = false;
-        _storeAvailabilityCacheFuture =
-            BulkScanCache.load().then((cache) => cache[widget.appId]);
+        _storeAvailabilityCacheFuture = BulkScanCache.load().then(
+          (cache) => cache[widget.appId],
+        );
       });
       // Independently check Play Store in the background so other store
       // buttons (F-Droid, APKPure, APKMirror) appear immediately from cache
@@ -1289,10 +1301,7 @@ class _AppPageState extends State<AppPage> {
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        onTap: () => launchUrlString(
-          url,
-          mode: LaunchMode.externalApplication,
-        ),
+        onTap: () => launchUrlString(url, mode: LaunchMode.externalApplication),
         onLongPress: () {
           _toastUrl(url);
           Clipboard.setData(ClipboardData(text: url));
@@ -1318,9 +1327,9 @@ class _AppPageState extends State<AppPage> {
             child: Text(
               label,
               style: Theme.of(ctx).textTheme.bodySmall?.copyWith(
-                    color: Theme.of(ctx).colorScheme.onSurfaceVariant,
-                    fontSize: 12,
-                  ),
+                color: Theme.of(ctx).colorScheme.onSurfaceVariant,
+                fontSize: 12,
+              ),
             ),
           ),
           Expanded(
@@ -1346,10 +1355,14 @@ class _AppPageState extends State<AppPage> {
           appPageAppsRebuildToken(provider, widget.appId),
     );
 
-    final AppsProvider appsProvider =
-        Provider.of<AppsProvider>(context, listen: false);
-    final SettingsProvider settingsProvider =
-        Provider.of<SettingsProvider>(context, listen: false);
+    final AppsProvider appsProvider = Provider.of<AppsProvider>(
+      context,
+      listen: false,
+    );
+    final SettingsProvider settingsProvider = Provider.of<SettingsProvider>(
+      context,
+      listen: false,
+    );
 
     final bool useIconPageColors = settingsProvider.matchAppPageToIconColors;
     var showAppWebpageFinal =
@@ -1361,14 +1374,14 @@ class _AppPageState extends State<AppPage> {
     bool areDownloadsRunning = appsProvider.areDownloadsRunning();
 
     AppInMemory? app = appsProvider.apps[widget.appId];
-    if (!_requestedMissingIconLoad &&
-        app != null &&
-        app.icon == null) {
+    if (!_requestedMissingIconLoad && app != null && app.icon == null) {
       _requestedMissingIconLoad = true;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
-        Provider.of<AppsProvider>(context, listen: false)
-            .updateAppIcon(widget.appId, ignoreCache: false);
+        Provider.of<AppsProvider>(
+          context,
+          listen: false,
+        ).updateAppIcon(widget.appId, ignoreCache: false);
       });
     }
     if (widget.openInEditMode &&
@@ -1378,8 +1391,10 @@ class _AppPageState extends State<AppPage> {
       _scheduledOpenInEditMode = true;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
-        final AppInMemory? freshApp =
-            Provider.of<AppsProvider>(context, listen: false).apps[widget.appId];
+        final AppInMemory? freshApp = Provider.of<AppsProvider>(
+          context,
+          listen: false,
+        ).apps[widget.appId];
         if (freshApp != null) {
           _startEdit(freshApp, appsProvider);
         }
@@ -1465,7 +1480,6 @@ class _AppPageState extends State<AppPage> {
     bool isVersionDetectionStandard =
         app?.app.additionalSettings['versionDetection'] == true;
 
-
     if (showAppWebpageFinal && app != null && !_webViewUrlLoaded) {
       _webViewUrlLoaded = true;
       final String webUrl = app.app.url;
@@ -1502,9 +1516,9 @@ class _AppPageState extends State<AppPage> {
               child: Text(
                 label,
                 style: Theme.of(ctx).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(ctx).colorScheme.onSurfaceVariant,
-                      fontSize: 12,
-                    ),
+                  color: Theme.of(ctx).colorScheme.onSurfaceVariant,
+                  fontSize: 12,
+                ),
               ),
             ),
             Expanded(
@@ -1530,9 +1544,9 @@ class _AppPageState extends State<AppPage> {
               child: Text(
                 label,
                 style: Theme.of(ctx).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(ctx).colorScheme.onSurfaceVariant,
-                      fontSize: 12,
-                    ),
+                  color: Theme.of(ctx).colorScheme.onSurfaceVariant,
+                  fontSize: 12,
+                ),
                 softWrap: false,
                 overflow: TextOverflow.visible,
               ),
@@ -1542,10 +1556,10 @@ class _AppPageState extends State<AppPage> {
               child: SelectableText(
                 value,
                 style: Theme.of(ctx).textTheme.bodySmall?.copyWith(
-                      fontFamily: 'monospace',
-                      fontWeight: FontWeight.w500,
-                      fontSize: 14,
-                    ),
+                  fontFamily: 'monospace',
+                  fontWeight: FontWeight.w500,
+                  fontSize: 14,
+                ),
               ),
             ),
           ],
@@ -1569,9 +1583,9 @@ class _AppPageState extends State<AppPage> {
               child: Text(
                 tr('latest'),
                 style: Theme.of(ctx).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(ctx).colorScheme.onSurfaceVariant,
-                      fontSize: 12,
-                    ),
+                  color: Theme.of(ctx).colorScheme.onSurfaceVariant,
+                  fontSize: 12,
+                ),
                 softWrap: false,
                 overflow: TextOverflow.visible,
               ),
@@ -1586,10 +1600,10 @@ class _AppPageState extends State<AppPage> {
                   SelectableText(
                     value,
                     style: Theme.of(ctx).textTheme.bodySmall?.copyWith(
-                          fontFamily: 'monospace',
-                          fontWeight: FontWeight.w500,
-                          fontSize: 14,
-                        ),
+                      fontFamily: 'monospace',
+                      fontWeight: FontWeight.w500,
+                      fontSize: 14,
+                    ),
                   ),
                   if (skipActive)
                     Container(
@@ -1598,15 +1612,17 @@ class _AppPageState extends State<AppPage> {
                         vertical: 4,
                       ),
                       decoration: BoxDecoration(
-                        color: Theme.of(ctx).colorScheme.surfaceContainerHighest,
+                        color: Theme.of(
+                          ctx,
+                        ).colorScheme.surfaceContainerHighest,
                         borderRadius: BorderRadius.circular(999),
                       ),
                       child: Text(
                         tr('latestVersionSkipped'),
                         style: Theme.of(ctx).textTheme.labelSmall?.copyWith(
-                              color: Theme.of(ctx).colorScheme.onSurfaceVariant,
-                              fontWeight: FontWeight.w500,
-                            ),
+                          color: Theme.of(ctx).colorScheme.onSurfaceVariant,
+                          fontWeight: FontWeight.w500,
+                        ),
                       ),
                     ),
                 ],
@@ -1624,11 +1640,11 @@ class _AppPageState extends State<AppPage> {
       VoidCallback? onTap,
     ) {
       final linkStyle = Theme.of(ctx).textTheme.bodySmall?.copyWith(
-            color: Theme.of(ctx).colorScheme.primary,
-            decoration: onTap != null ? TextDecoration.underline : null,
-            fontWeight: FontWeight.w500,
-            fontSize: 14,
-          );
+        color: Theme.of(ctx).colorScheme.primary,
+        decoration: onTap != null ? TextDecoration.underline : null,
+        fontWeight: FontWeight.w500,
+        fontSize: 14,
+      );
       return Padding(
         padding: const EdgeInsets.only(bottom: 6),
         child: Row(
@@ -1640,9 +1656,9 @@ class _AppPageState extends State<AppPage> {
               child: Text(
                 label,
                 style: Theme.of(ctx).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(ctx).colorScheme.onSurfaceVariant,
-                      fontSize: 12,
-                    ),
+                  color: Theme.of(ctx).colorScheme.onSurfaceVariant,
+                  fontSize: 12,
+                ),
                 softWrap: false,
                 overflow: TextOverflow.visible,
               ),
@@ -1651,17 +1667,13 @@ class _AppPageState extends State<AppPage> {
             Expanded(
               child: GestureDetector(
                 onTap: onTap,
-                child: Text(
-                  value,
-                  style: linkStyle,
-                ),
+                child: Text(value, style: linkStyle),
               ),
             ),
           ],
         ),
       );
     }
-
 
     Widget buildAboutBlock(BuildContext themeContext) {
       if (app?.app.additionalSettings['about'] is! String ||
@@ -1678,10 +1690,12 @@ class _AppPageState extends State<AppPage> {
       return GestureDetector(
         onLongPress: () {
           Clipboard.setData(ClipboardData(text: aboutRaw));
-          ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-            content: Text(tr('copiedToClipboard')),
-            duration: const Duration(seconds: 4),
-          ));
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(tr('copiedToClipboard')),
+              duration: const Duration(seconds: 4),
+            ),
+          );
         },
         child: Markdown(
           physics: const NeverScrollableScrollPhysics(),
@@ -1713,28 +1727,32 @@ class _AppPageState extends State<AppPage> {
       final ThemeData pageTheme = Theme.of(pageThemeContext);
       final undeterminedTrackOnlyInstalled =
           trackOnly &&
-              app?.app.additionalSettings['trackOnlyUndeterminedInstalledVersion'] ==
-                  true &&
-              app?.app.installedVersion == null;
+          app?.app.additionalSettings['trackOnlyUndeterminedInstalledVersion'] ==
+              true &&
+          app?.app.installedVersion == null;
       bool installed = app?.app.installedVersion != null;
       final String? installedVerStr = app?.app.installedVersion;
       final String latestVerStr = app?.app.latestVersion ?? '';
-      final effectivelyEqual = installed &&
+      final effectivelyEqual =
+          installed &&
           installedVerStr != null &&
           installedVerStr != latestVerStr &&
           versionsEffectivelyEqual(installedVerStr, latestVerStr);
-      final bool versionOrderUnclearState = installedVerStr != null &&
+      final bool versionOrderUnclearState =
+          installedVerStr != null &&
           latestVerStr.isNotEmpty &&
           versionOrderIsUnclear(installedVerStr, latestVerStr);
       final int? versionCmp = installedVerStr != null && latestVerStr.isNotEmpty
           ? compareVersionsByNumericSegments(installedVerStr, latestVerStr)
           : null;
-      final bool newerOnDeviceState = installed &&
+      final bool newerOnDeviceState =
+          installed &&
           installedVerStr != null &&
           installedVerStr != latestVerStr &&
           !effectivelyEqual &&
           versionCmp == 1;
-      final bool sameVersionVerdict = installed &&
+      final bool sameVersionVerdict =
+          installed &&
           installedVerStr != null &&
           latestVerStr.isNotEmpty &&
           !effectivelyEqual &&
@@ -1743,8 +1761,10 @@ class _AppPageState extends State<AppPage> {
           installedVersionIsNewerOrEqual(installedVerStr, latestVerStr);
       var changeLogFn = app != null ? getChangeLogFn(context, app.app) : null;
 
-      final lastUpdateCheckLabel =
-          tr('lastUpdateCheckX', args: [tr('never')]).split(':').first.trim();
+      final lastUpdateCheckLabel = tr(
+        'lastUpdateCheckX',
+        args: [tr('never')],
+      ).split(':').first.trim();
       final lastUpdateCheckValue = app?.app.lastUpdateCheck == null
           ? tr('never')
           : formatDateTimeToMinute(app!.app.lastUpdateCheck!);
@@ -1756,7 +1776,8 @@ class _AppPageState extends State<AppPage> {
         });
         try {
           final App appToSave = app.app.deepCopy();
-          appToSave.additionalSettings['trackOnlyUndeterminedInstalledVersion'] =
+          appToSave
+                  .additionalSettings['trackOnlyUndeterminedInstalledVersion'] =
               false;
           await appsProvider.saveApps([appToSave]);
         } catch (err) {
@@ -1811,9 +1832,9 @@ class _AppPageState extends State<AppPage> {
                 onPressed: updating
                     ? null
                     : () => Navigator.pop(
-                          dialogContext,
-                          packageIdController.text.trim(),
-                        ),
+                        dialogContext,
+                        packageIdController.text.trim(),
+                      ),
                 child: Text(tr('ok')),
               ),
             ],
@@ -1971,7 +1992,11 @@ class _AppPageState extends State<AppPage> {
           versionRow(pageThemeContext, tr('installed'), tr('unknown')),
         );
         versionCardChildren.add(
-          versionRow(pageThemeContext, tr('latest'), app?.app.latestVersion ?? '-'),
+          versionRow(
+            pageThemeContext,
+            tr('latest'),
+            app?.app.latestVersion ?? '-',
+          ),
         );
         if (changeLogFn != null || app?.app.releaseDate != null) {
           versionCardChildren.add(
@@ -1997,8 +2022,9 @@ class _AppPageState extends State<AppPage> {
                   ? null
                   : () async {
                       try {
-                        await appsProvider.downloadAppAssets(
-                            [app.app.id], context);
+                        await appsProvider.downloadAppAssets([
+                          app.app.id,
+                        ], context);
                       } catch (e) {
                         if (!context.mounted) return;
                         showError(e, context);
@@ -2010,7 +2036,11 @@ class _AppPageState extends State<AppPage> {
       } else {
         if (installed) {
           versionCardChildren.add(
-            versionRow(pageThemeContext, tr('installed'), app?.app.installedVersion ?? ''),
+            versionRow(
+              pageThemeContext,
+              tr('installed'),
+              app?.app.installedVersion ?? '',
+            ),
           );
         } else {
           versionCardChildren.add(
@@ -2048,8 +2078,9 @@ class _AppPageState extends State<AppPage> {
                   ? null
                   : () async {
                       try {
-                        await appsProvider.downloadAppAssets(
-                            [app.app.id], context);
+                        await appsProvider.downloadAppAssets([
+                          app.app.id,
+                        ], context);
                       } catch (e) {
                         if (!context.mounted) return;
                         showError(e, context);
@@ -2073,57 +2104,54 @@ class _AppPageState extends State<AppPage> {
 
       final bool trackOnlyUsesTemporaryPackageId =
           app?.app.additionalSettings['trackOnlyTemporaryPackageId'] == true;
-      final Widget? trackOnlyInstalledErrorCard =
-          undeterminedTrackOnlyInstalled
-              ? _materialAppPageSectionCard(
-                  pageThemeContext,
-                  tr('error'),
-                  [
-                    SelectableText(
-                      trackOnlyUsesTemporaryPackageId
-                          ? tr('trackOnlyTempPackageIdInstalledVersion')
-                          : tr('trackOnlyUndeterminedInstalledVersion'),
-                      style: pageTheme.textTheme.bodySmall?.copyWith(
-                            color: pageTheme.colorScheme.onErrorContainer,
-                            height: 1.35,
-                          ),
+      final Widget? trackOnlyInstalledErrorCard = undeterminedTrackOnlyInstalled
+          ? _materialAppPageSectionCard(
+              pageThemeContext,
+              tr('error'),
+              [
+                SelectableText(
+                  trackOnlyUsesTemporaryPackageId
+                      ? tr('trackOnlyTempPackageIdInstalledVersion')
+                      : tr('trackOnlyUndeterminedInstalledVersion'),
+                  style: pageTheme.textTheme.bodySmall?.copyWith(
+                    color: pageTheme.colorScheme.onErrorContainer,
+                    height: 1.35,
+                  ),
+                ),
+                const SizedBox(height: 14),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  children: [
+                    FilledButton.tonalIcon(
+                      onPressed: updating || app == null
+                          ? null
+                          : openFixTrackOnlyPackageIdDialog,
+                      icon: const Icon(Icons.edit_outlined, size: 20),
+                      label: Text(tr('fixPackageId')),
                     ),
-                    const SizedBox(height: 14),
-                    Wrap(
-                      spacing: 8,
-                      runSpacing: 8,
-                      crossAxisAlignment: WrapCrossAlignment.center,
-                      children: [
-                        FilledButton.tonalIcon(
-                          onPressed: updating || app == null
-                              ? null
-                              : openFixTrackOnlyPackageIdDialog,
-                          icon: const Icon(Icons.edit_outlined, size: 20),
-                          label: Text(tr('fixPackageId')),
-                        ),
-                        FilledButton.tonal(
-                          onPressed: updating || app == null
-                              ? null
-                              : markTrackOnlyAsNotInstalledOnDevice,
-                          child: Text(tr('itsNotInstalled')),
-                        ),
-                      ],
+                    FilledButton.tonal(
+                      onPressed: updating || app == null
+                          ? null
+                          : markTrackOnlyAsNotInstalledOnDevice,
+                      child: Text(tr('itsNotInstalled')),
                     ),
                   ],
-                  sectionBackgroundColor:
-                      pageTheme.colorScheme.errorContainer,
-                  sectionTitleColor:
-                      pageTheme.colorScheme.onErrorContainer,
-                )
-              : null;
+                ),
+              ],
+              sectionBackgroundColor: pageTheme.colorScheme.errorContainer,
+              sectionTitleColor: pageTheme.colorScheme.onErrorContainer,
+            )
+          : null;
 
-      final detailsValueStyle =
-          pageTheme.textTheme.bodySmall!.copyWith(
-                fontSize: 14,
-                fontWeight: FontWeight.w500,
-              );
-      final detailsMonoValueStyle =
-          detailsValueStyle.copyWith(fontFamily: 'monospace');
+      final detailsValueStyle = pageTheme.textTheme.bodySmall!.copyWith(
+        fontSize: 14,
+        fontWeight: FontWeight.w500,
+      );
+      final detailsMonoValueStyle = detailsValueStyle.copyWith(
+        fontFamily: 'monospace',
+      );
 
       final String? alternateStoresPackageId = app?.app.id;
       final String? alternateStoresTrackedUrl = app?.app.url;
@@ -2136,54 +2164,58 @@ class _AppPageState extends State<AppPage> {
             app.app.id,
             valueStyle: detailsMonoValueStyle,
           ),
-        if (app?.installedInfo != null) () {
-          final appType = classifyAppType(app!);
-          final (IconData typeIcon, Color typeColor, String typeLabel) =
-              switch (appType) {
-            AppTypeGroup.user => (
+        if (app?.installedInfo != null)
+          () {
+            final appType = classifyAppType(app!);
+            final (
+              IconData typeIcon,
+              Color typeColor,
+              String typeLabel,
+            ) = switch (appType) {
+              AppTypeGroup.user => (
                 Icons.person_rounded,
                 Colors.green,
                 tr('appTypeUser'),
               ),
-            AppTypeGroup.system => (
+              AppTypeGroup.system => (
                 Icons.android_rounded,
                 Colors.grey,
                 tr('appTypeSystem'),
               ),
-            AppTypeGroup.privileged => (
+              AppTypeGroup.privileged => (
                 Icons.security_rounded,
                 Colors.grey.shade600,
                 tr('appTypePrivileged'),
               ),
-          };
-          return Padding(
-            padding: const EdgeInsets.only(bottom: 8),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                SizedBox(
-                  width: 100,
-                  child: Text(
-                    tr('appType'),
-                    style: Theme.of(pageThemeContext).textTheme.bodySmall
-                        ?.copyWith(
-                      color: Theme.of(pageThemeContext)
-                          .colorScheme
-                          .onSurfaceVariant,
-                      fontSize: 12,
+            };
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  SizedBox(
+                    width: 100,
+                    child: Text(
+                      tr('appType'),
+                      style: Theme.of(pageThemeContext).textTheme.bodySmall
+                          ?.copyWith(
+                            color: Theme.of(
+                              pageThemeContext,
+                            ).colorScheme.onSurfaceVariant,
+                            fontSize: 12,
+                          ),
                     ),
                   ),
-                ),
-                Icon(typeIcon, size: 14, color: typeColor),
-                const SizedBox(width: 4),
-                Text(
-                  typeLabel,
-                  style: Theme.of(pageThemeContext).textTheme.bodySmall,
-                ),
-              ],
-            ),
-          );
-        }(),
+                  Icon(typeIcon, size: 14, color: typeColor),
+                  const SizedBox(width: 4),
+                  Text(
+                    typeLabel,
+                    style: Theme.of(pageThemeContext).textTheme.bodySmall,
+                  ),
+                ],
+              ),
+            );
+          }(),
         if (app?.app.url != null && app!.app.url.isNotEmpty)
           _detailRowTrackedSource(
             pageThemeContext,
@@ -2205,21 +2237,27 @@ class _AppPageState extends State<AppPage> {
                 storeData: storeData,
                 storeName: 'PlayStore',
                 fallbackUrl: null,
-                alreadyTracked:
-                    _trackedUrlIsFromHost(trackedUrl, 'play.google.com'),
+                alreadyTracked: _trackedUrlIsFromHost(
+                  trackedUrl,
+                  'play.google.com',
+                ),
               );
 
               final fdroidUrl = _resolveStoreUrl(
                 storeData: storeData,
                 storeName: 'F-Droid',
                 fallbackUrl: 'https://f-droid.org/packages/$pid/',
-                alreadyTracked: _trackedUrlIsFromHost(trackedUrl, 'f-droid.org'),
+                alreadyTracked: _trackedUrlIsFromHost(
+                  trackedUrl,
+                  'f-droid.org',
+                ),
               );
 
               final apkpureUrl = _resolveStoreUrl(
                 storeData: storeData,
                 storeName: 'APKPure',
-                fallbackUrl: null, // search-by-package-ID is not useful; only show confirmed URL
+                fallbackUrl:
+                    null, // search-by-package-ID is not useful; only show confirmed URL
                 alreadyTracked: _trackedUrlIsFromHost(trackedUrl, 'apkpure.'),
               );
 
@@ -2228,7 +2266,10 @@ class _AppPageState extends State<AppPage> {
                 storeName: 'APKMirror',
                 fallbackUrl:
                     'https://www.apkmirror.com/?post_type=app_release&searchtype=apk&s=${Uri.encodeComponent(pid)}',
-                alreadyTracked: _trackedUrlIsFromHost(trackedUrl, 'apkmirror.com'),
+                alreadyTracked: _trackedUrlIsFromHost(
+                  trackedUrl,
+                  'apkmirror.com',
+                ),
               );
 
               if (playStoreUrl == null &&
@@ -2301,63 +2342,61 @@ class _AppPageState extends State<AppPage> {
                 child: Text(
                   tr('categories'),
                   style: pageTheme.textTheme.bodySmall?.copyWith(
-                        color: pageTheme.colorScheme.onSurfaceVariant,
-                        fontSize: 12,
-                      ),
+                    color: pageTheme.colorScheme.onSurfaceVariant,
+                    fontSize: 12,
+                  ),
                 ),
               ),
               Expanded(
                 child: (app?.app.categories ?? []).isEmpty
                     ? Text(tr('none'), style: detailsValueStyle)
                     : Wrap(
-                          spacing: 6,
-                          runSpacing: 4,
-                          alignment: WrapAlignment.start,
-                          crossAxisAlignment: WrapCrossAlignment.center,
-                          children: [
-                            ...(app?.app.categories ?? []).map(
-                              (categoryName) {
-                                final colorArgb =
-                                    settingsProvider.categories[categoryName];
-                                if (colorArgb != null) {
-                                  final fill = Color(colorArgb);
-                                  return Chip(
-                                    label: Text(
-                                      categoryName,
-                                      style: TextStyle(
-                                        color: _labelColorOnCategoryFill(fill),
-                                        fontSize: 14,
-                                        fontWeight: FontWeight.w500,
-                                      ),
-                                    ),
-                                    backgroundColor: fill,
-                                    side: BorderSide.none,
-                                    padding: const EdgeInsets.symmetric(
-                                      horizontal: 10,
-                                      vertical: 2,
-                                    ),
-                                    materialTapTargetSize:
-                                        MaterialTapTargetSize.shrinkWrap,
-                                    visualDensity: VisualDensity.compact,
-                                  );
-                                }
-                                return Chip(
-                                  label: Text(
-                                    categoryName,
-                                    style: detailsValueStyle,
+                        spacing: 6,
+                        runSpacing: 4,
+                        alignment: WrapAlignment.start,
+                        crossAxisAlignment: WrapCrossAlignment.center,
+                        children: [
+                          ...(app?.app.categories ?? []).map((categoryName) {
+                            final colorArgb =
+                                settingsProvider.categories[categoryName];
+                            if (colorArgb != null) {
+                              final fill = Color(colorArgb);
+                              return Chip(
+                                label: Text(
+                                  categoryName,
+                                  style: TextStyle(
+                                    color: _labelColorOnCategoryFill(fill),
+                                    fontSize: 14,
+                                    fontWeight: FontWeight.w500,
                                   ),
-                                  padding: const EdgeInsets.symmetric(
-                                    horizontal: 12,
-                                    vertical: 4,
-                                  ),
-                                  materialTapTargetSize:
-                                      MaterialTapTargetSize.shrinkWrap,
-                                  visualDensity: VisualDensity.compact,
-                                );
-                              },
-                            ),
-                          ],
-                        ),
+                                ),
+                                backgroundColor: fill,
+                                side: BorderSide.none,
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 10,
+                                  vertical: 2,
+                                ),
+                                materialTapTargetSize:
+                                    MaterialTapTargetSize.shrinkWrap,
+                                visualDensity: VisualDensity.compact,
+                              );
+                            }
+                            return Chip(
+                              label: Text(
+                                categoryName,
+                                style: detailsValueStyle,
+                              ),
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 12,
+                                vertical: 4,
+                              ),
+                              materialTapTargetSize:
+                                  MaterialTapTargetSize.shrinkWrap,
+                              visualDensity: VisualDensity.compact,
+                            );
+                          }),
+                        ],
+                      ),
               ),
             ],
           ),
@@ -2379,11 +2418,9 @@ class _AppPageState extends State<AppPage> {
           detailsCard,
           if (app?.app.additionalSettings['about'] is String &&
               app?.app.additionalSettings['about'].isNotEmpty)
-            _materialAppPageSectionCard(
-              pageThemeContext,
-              tr('notes'),
-              [buildAboutBlock(pageThemeContext)],
-            ),
+            _materialAppPageSectionCard(pageThemeContext, tr('notes'), [
+              buildAboutBlock(pageThemeContext),
+            ]),
         ],
       );
     }
@@ -2408,8 +2445,8 @@ class _AppPageState extends State<AppPage> {
         onTap: _editMode
             ? null
             : (app?.installedInfo != null
-                ? () => pm.openApp(widget.appId)
-                : null),
+                  ? () => pm.openApp(widget.appId)
+                  : null),
         emptyPlaceholder: Container(
           height: scaledIconSize,
           width: scaledIconSize,
@@ -2445,17 +2482,19 @@ class _AppPageState extends State<AppPage> {
                         ListenableBuilder(
                           listenable: _nameController,
                           builder: (BuildContext context, Widget? child) {
-                            final ColorScheme heroScheme =
-                                Theme.of(themeContext).colorScheme;
+                            final ColorScheme heroScheme = Theme.of(
+                              themeContext,
+                            ).colorScheme;
                             final String previewText =
                                 _nameController.text.isEmpty
-                                    ? tr('app')
-                                    : _nameController.text;
+                                ? tr('app')
+                                : _nameController.text;
                             return Text(
                               previewText,
                               style: titleStyle?.copyWith(
                                 fontWeight: FontWeight.w700,
-                                fontSize: (titleStyle.fontSize ?? 22) *
+                                fontSize:
+                                    (titleStyle.fontSize ?? 22) *
                                     heroScale *
                                     1.06,
                                 color: _nameController.text.isEmpty
@@ -2471,11 +2510,10 @@ class _AppPageState extends State<AppPage> {
                         Text(
                           app?.name ?? tr('app'),
                           style: titleStyle?.copyWith(
-                                fontWeight: FontWeight.w700,
-                                fontSize: (titleStyle.fontSize ?? 22) *
-                                    heroScale *
-                                    1.06,
-                              ),
+                            fontWeight: FontWeight.w700,
+                            fontSize:
+                                (titleStyle.fontSize ?? 22) * heroScale * 1.06,
+                          ),
                           maxLines: 2,
                           overflow: TextOverflow.ellipsis,
                         ),
@@ -2483,13 +2521,12 @@ class _AppPageState extends State<AppPage> {
                       Text(
                         tr('byX', args: [app?.author ?? tr('unknown')]),
                         style: bylineStyle?.copyWith(
-                              color: Theme.of(themeContext)
-                                  .colorScheme
-                                  .onSurfaceVariant,
-                              fontSize: (bylineStyle.fontSize ?? 12) *
-                                  heroScale *
-                                  1.08,
-                            ),
+                          color: Theme.of(
+                            themeContext,
+                          ).colorScheme.onSurfaceVariant,
+                          fontSize:
+                              (bylineStyle.fontSize ?? 12) * heroScale * 1.08,
+                        ),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                       ),
@@ -2590,8 +2627,7 @@ class _AppPageState extends State<AppPage> {
                       Text(
                         tr('byX', args: [app?.author ?? tr('unknown')]),
                         style: dialogColumnTheme.textTheme.bodySmall?.copyWith(
-                          color: dialogColumnTheme
-                              .colorScheme.onSurfaceVariant,
+                          color: dialogColumnTheme.colorScheme.onSurfaceVariant,
                         ),
                       ),
                       Padding(
@@ -2618,7 +2654,8 @@ class _AppPageState extends State<AppPage> {
 
     Widget getAppWebView(BuildContext themeContext) {
       if (app == null) return const SizedBox.shrink();
-      final Color webViewSurface = Color.lerp(
+      final Color webViewSurface =
+          Color.lerp(
             Theme.of(themeContext).colorScheme.surface,
             Colors.black,
             Theme.of(themeContext).brightness == Brightness.dark
@@ -2652,7 +2689,9 @@ class _AppPageState extends State<AppPage> {
                   final App? updatedApp = app?.app.deepCopy();
                   if (updatedApp != null) {
                     updatedApp.installedVersion = updatedApp.latestVersion;
-                    updatedApp.additionalSettings.remove('skippedLatestVersion');
+                    updatedApp.additionalSettings.remove(
+                      'skippedLatestVersion',
+                    );
                     appsProvider.saveApps([updatedApp]);
                   }
                   Navigator.of(context).pop();
@@ -2668,8 +2707,10 @@ class _AppPageState extends State<AppPage> {
     getBottomCenterActions(BuildContext themeContext) {
       final ThemeData actionTheme = Theme.of(themeContext);
       const double expressiveRadius = 26;
-      const EdgeInsets expressivePadding =
-          EdgeInsets.symmetric(horizontal: 16, vertical: 14);
+      const EdgeInsets expressivePadding = EdgeInsets.symmetric(
+        horizontal: 16,
+        vertical: 14,
+      );
       const Size expressiveMinimumSize = Size(48, 52);
       final RoundedRectangleBorder expressiveShape = RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(expressiveRadius),
@@ -2684,10 +2725,12 @@ class _AppPageState extends State<AppPage> {
         shadowColor: actionTheme.colorScheme.shadow,
         backgroundColor: actionTheme.colorScheme.primary,
         foregroundColor: actionTheme.colorScheme.onPrimary,
-        disabledBackgroundColor:
-            actionTheme.colorScheme.onSurface.withAlpha(31),
-        disabledForegroundColor:
-            actionTheme.colorScheme.onSurface.withAlpha(97),
+        disabledBackgroundColor: actionTheme.colorScheme.onSurface.withAlpha(
+          31,
+        ),
+        disabledForegroundColor: actionTheme.colorScheme.onSurface.withAlpha(
+          97,
+        ),
         tapTargetSize: MaterialTapTargetSize.shrinkWrap,
       );
 
@@ -2695,13 +2738,16 @@ class _AppPageState extends State<AppPage> {
         return const SizedBox.shrink();
       }
 
-      // Update label shows size when known (GitHub apps); plain otherwise.
+      // Update label shows size when known from the source metadata.
       final int? knownApkSizeBytes = app?.app.apkSizeBytes;
-      // Appends "· 43 MB" to install/update labels when size is known (GitHub).
-      String sizeAnnotated(String base) =>
-          !trackOnly && knownApkSizeBytes != null
-          ? '$base · ${_formatBytes(knownApkSizeBytes)}'
-          : base;
+      // Appends "· 43 MB" to install/update labels when size is known.
+      String sizeAnnotated(String base) {
+        if (knownApkSizeBytes == null) {
+          return base;
+        }
+        return '$base · ${_formatBytes(knownApkSizeBytes)}';
+      }
+
       final String updateLabel = sizeAnnotated(tr('update'));
       final String installLabel = sizeAnnotated(tr('install'));
 
@@ -2710,14 +2756,13 @@ class _AppPageState extends State<AppPage> {
         final double dp = app!.downloadProgress!;
         final bool isInstalling = dp < 0;
         final int? totalBytes = app.downloadTotalBytes;
-        final String bytesLabel =
-            !isInstalling && totalBytes != null
+        final String bytesLabel = !isInstalling && totalBytes != null
             ? ' · ${_formatBytes((dp / 100 * totalBytes).round())} / ${_formatBytes(totalBytes)}'
             : '';
         final String label = isInstalling
             ? '${tr('installing')}…'
             : 'Downloading ${dp.round()}%$bytesLabel';
-        return ClipRRect(
+        final Widget progressBar = ClipRRect(
           borderRadius: BorderRadius.circular(expressiveRadius),
           child: SizedBox(
             height: 52,
@@ -2732,8 +2777,9 @@ class _AppPageState extends State<AppPage> {
                   child: FractionallySizedBox(
                     widthFactor: isInstalling ? 1.0 : dp / 100,
                     child: Container(
-                      color: actionTheme.colorScheme.primary
-                          .withAlpha(isInstalling ? 55 : 220),
+                      color: actionTheme.colorScheme.primary.withAlpha(
+                        isInstalling ? 55 : 220,
+                      ),
                     ),
                   ),
                 ),
@@ -2755,6 +2801,20 @@ class _AppPageState extends State<AppPage> {
             ),
           ),
         );
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            progressBar,
+            if (!isInstalling)
+              Center(
+                child: TextButton(
+                  onPressed: () => appsProvider.cancelDownload(app.app.id),
+                  child: Text(tr('cancel')),
+                ),
+              ),
+          ],
+        );
       }
 
       final bool actionBlocked = updating || areDownloadsRunning;
@@ -2768,13 +2828,15 @@ class _AppPageState extends State<AppPage> {
           app != null && isSkipActiveForCurrentLatest(app.app);
       final bool trackOnlyHasVersionUpdate =
           trackOnly && (actionableUpdate || uncertainUpdate);
-      final bool nonStandardVersionBehind = !trackOnly &&
+      final bool nonStandardVersionBehind =
+          !trackOnly &&
           !isVersionDetectionStandard &&
           (actionableUpdate || uncertainUpdate);
       // Version order unclear: user should use Update and/or Skip only; no manual
       // "mark as latest" second button (mutually exclusive with actionableUpdate).
       final bool uncertainOnly = uncertainUpdate;
-      final bool primaryActionEnabled = !actionBlocked &&
+      final bool primaryActionEnabled =
+          !actionBlocked &&
           (installedVersionIsNull ||
               ((actionableUpdate || uncertainUpdate) && !skipActive));
 
@@ -2783,7 +2845,8 @@ class _AppPageState extends State<AppPage> {
         if (appForSkip == null || appForSkip.installedVersion == null) {
           return primaryBar;
         }
-        final bool showSkipToggle = appHasActionableUpdate(appForSkip) ||
+        final bool showSkipToggle =
+            appHasActionableUpdate(appForSkip) ||
             versionOrderUncertainUpdate(appForSkip) ||
             isSkipActiveForCurrentLatest(appForSkip);
         if (!showSkipToggle) {
@@ -2795,7 +2858,8 @@ class _AppPageState extends State<AppPage> {
           if (isSkipActiveForCurrentLatest(copy)) {
             copy.additionalSettings.remove('skippedLatestVersion');
           } else {
-            copy.additionalSettings['skippedLatestVersion'] = copy.latestVersion;
+            copy.additionalSettings['skippedLatestVersion'] =
+                copy.latestVersion;
           }
           await appsProvider.saveApps([copy]);
           if (mounted) {
@@ -2871,7 +2935,7 @@ class _AppPageState extends State<AppPage> {
                       fit: BoxFit.scaleDown,
                       alignment: Alignment.center,
                       child: Text(
-                        tr('update'),
+                        updateLabel,
                         maxLines: 1,
                         textAlign: TextAlign.center,
                       ),
@@ -2911,7 +2975,7 @@ class _AppPageState extends State<AppPage> {
               fit: BoxFit.scaleDown,
               alignment: Alignment.center,
               child: Text(
-                tr('update'),
+                updateLabel,
                 maxLines: 1,
                 textAlign: TextAlign.center,
               ),
@@ -2951,8 +3015,9 @@ class _AppPageState extends State<AppPage> {
                 Expanded(
                   child: FilledButton(
                     style: expressiveFilled,
-                    onPressed:
-                        markUpdatedActionBlocked ? null : showMarkUpdatedDialog,
+                    onPressed: markUpdatedActionBlocked
+                        ? null
+                        : showMarkUpdatedDialog,
                     child: FittedBox(
                       fit: BoxFit.scaleDown,
                       alignment: Alignment.center,
@@ -3031,21 +3096,19 @@ class _AppPageState extends State<AppPage> {
           border: Border(
             top: BorderSide(
               color: Theme.of(themeContext).brightness == Brightness.dark
-                  ? Theme.of(themeContext)
-                      .colorScheme.outlineVariant
-                      .withAlpha(140)
-                  : Theme.of(themeContext)
-                      .colorScheme.outlineVariant
-                      .withAlpha(70),
+                  ? Theme.of(
+                      themeContext,
+                    ).colorScheme.outlineVariant.withAlpha(140)
+                  : Theme.of(
+                      themeContext,
+                    ).colorScheme.outlineVariant.withAlpha(70),
             ),
           ),
           boxShadow: [
             BoxShadow(
               color: Theme.of(themeContext).colorScheme.shadow.withAlpha(
-                    Theme.of(themeContext).brightness == Brightness.dark
-                        ? 130
-                        : 40,
-                  ),
+                Theme.of(themeContext).brightness == Brightness.dark ? 130 : 40,
+              ),
               blurRadius: Theme.of(themeContext).brightness == Brightness.dark
                   ? 18
                   : 12,
@@ -3104,14 +3167,16 @@ class _AppPageState extends State<AppPage> {
                                       (_) => AdditionalOptionsPage(
                                         appId: widget.appId,
                                         onAfterSave:
-                                            (String savedAppId,
-                                                bool versionDetectionJustEnabled) async {
-                                          await _runCheckUpdate(
-                                            savedAppId,
-                                            resetVersion:
-                                                versionDetectionJustEnabled,
-                                          );
-                                        },
+                                            (
+                                              String savedAppId,
+                                              bool versionDetectionJustEnabled,
+                                            ) async {
+                                              await _runCheckUpdate(
+                                                savedAppId,
+                                                resetVersion:
+                                                    versionDetectionJustEnabled,
+                                              );
+                                            },
                                       ),
                                     ),
                                   );
@@ -3135,24 +3200,25 @@ class _AppPageState extends State<AppPage> {
                                   child: Builder(
                                     builder:
                                         (BuildContext dialogThemedContext) {
-                                      return AlertDialog(
-                                        scrollable: true,
-                                        content: getFullInfoColumn(
-                                          dialogThemedContext,
-                                          small: true,
-                                        ),
-                                        title: Text(app.name),
-                                        actions: [
-                                          TextButton(
-                                            onPressed: () {
-                                              Navigator.of(dialogRouteContext)
-                                                  .pop();
-                                            },
-                                            child: Text(tr('continue')),
-                                          ),
-                                        ],
-                                      );
-                                    },
+                                          return AlertDialog(
+                                            scrollable: true,
+                                            content: getFullInfoColumn(
+                                              dialogThemedContext,
+                                              small: true,
+                                            ),
+                                            title: Text(app.name),
+                                            actions: [
+                                              TextButton(
+                                                onPressed: () {
+                                                  Navigator.of(
+                                                    dialogRouteContext,
+                                                  ).pop();
+                                                },
+                                                child: Text(tr('continue')),
+                                              ),
+                                            ],
+                                          );
+                                        },
                                   ),
                                 );
                               },
@@ -3167,7 +3233,8 @@ class _AppPageState extends State<AppPage> {
                         app?.app.installedVersion != null) {
                       final String ins = app!.app.installedVersion!;
                       final String lat = app.app.latestVersion;
-                      final bool showResetInstall = ins == lat ||
+                      final bool showResetInstall =
+                          ins == lat ||
                           versionsEffectivelyEqual(ins, lat) ||
                           (installedVersionIsNewerOrEqual(ins, lat) &&
                               !versionOrderIsUnclear(ins, lat));
@@ -3201,9 +3268,9 @@ class _AppPageState extends State<AppPage> {
                                 if (appRow == null) return;
                                 final RemoveAppsWithModalResult removeResult =
                                     await appsProvider.removeAppsWithModal(
-                                  themeContext,
-                                  [appRow.app],
-                                );
+                                      themeContext,
+                                      [appRow.app],
+                                    );
                                 if (removeResult.shouldShowSnackBar &&
                                     messenger != null) {
                                   final Set<String> undoAppIds =
@@ -3223,14 +3290,15 @@ class _AppPageState extends State<AppPage> {
                                                 label: tr('undo'),
                                                 onPressed: () => appsProvider
                                                     .undoDeferredObtainiumRemovals(
-                                                  undoAppIds,
-                                                ),
+                                                      undoAppIds,
+                                                    ),
                                               )
                                             : null,
                                       ),
                                     );
                                 }
-                                if (removeResult.obtainiumEntryRemovedOrScheduled &&
+                                if (removeResult
+                                        .obtainiumEntryRemovedOrScheduled &&
                                     themeContext.mounted) {
                                   Navigator.of(themeContext).pop();
                                 }
@@ -3242,9 +3310,7 @@ class _AppPageState extends State<AppPage> {
                     return Row(
                       children: [
                         for (final Widget actionWidget in bottomBarActions)
-                          Expanded(
-                            child: Center(child: actionWidget),
-                          ),
+                          Expanded(child: Center(child: actionWidget)),
                       ],
                     );
                   },
@@ -3300,8 +3366,9 @@ class _AppPageState extends State<AppPage> {
                   break;
                 case _UnsavedAction.saveAndExit:
                   final appsProvider = Provider.of<AppsProvider>(
-                      themedPageContext,
-                      listen: false);
+                    themedPageContext,
+                    listen: false,
+                  );
                   await _saveEdit(freshApp, appsProvider);
                   if (widget.openInEditMode) {
                     shouldPopPage = true;
@@ -3318,110 +3385,114 @@ class _AppPageState extends State<AppPage> {
               }
             },
             child: Scaffold(
-            resizeToAvoidBottomInset: true,
-            appBar: showAppWebpageFinal ? AppBar() : null,
-            backgroundColor: appPageDeeperSurfaceColor(
-              pageColorSchemeForPage.surface,
-              pageBrightness,
-            ),
-            floatingActionButton:
-                _editModeFloatingActionButtons(
-              themedPageContext,
-              app,
-              appsProvider,
-              pageThemeForPage,
-            ),
-            floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
-            body: RefreshIndicator(
-              displacement: 20,
-              child: showAppWebpageFinal
-                  ? getAppWebView(themedPageContext)
-                  : CustomScrollView(
-                      controller: _appPageScrollController,
-                      cacheExtent: 1600,
-                      physics: const AlwaysScrollableScrollPhysics(
-                        parent: ClampingScrollPhysics(),
-                      ),
-                      slivers: [
-                        SliverToBoxAdapter(
-                          child: SafeArea(
-                            top: true,
-                            bottom: false,
-                            child: Padding(
-                              padding: const EdgeInsets.only(top: 12),
-                              child: Column(
-                                crossAxisAlignment:
-                                    CrossAxisAlignment.stretch,
-                                children: [
-                                  Row(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.center,
-                                    children: [
-                                      IconButton(
-                                        icon: const Icon(Icons.arrow_back),
-                                        onPressed: updating
-                                            ? null
-                                            : () => Navigator.of(
+              resizeToAvoidBottomInset: true,
+              appBar: showAppWebpageFinal ? AppBar() : null,
+              backgroundColor: appPageDeeperSurfaceColor(
+                pageColorSchemeForPage.surface,
+                pageBrightness,
+              ),
+              floatingActionButton: _editModeFloatingActionButtons(
+                themedPageContext,
+                app,
+                appsProvider,
+                pageThemeForPage,
+              ),
+              floatingActionButtonLocation:
+                  FloatingActionButtonLocation.endFloat,
+              body: RefreshIndicator(
+                displacement: 20,
+                child: showAppWebpageFinal
+                    ? getAppWebView(themedPageContext)
+                    : CustomScrollView(
+                        controller: _appPageScrollController,
+                        cacheExtent: 1600,
+                        physics: const AlwaysScrollableScrollPhysics(
+                          parent: ClampingScrollPhysics(),
+                        ),
+                        slivers: [
+                          SliverToBoxAdapter(
+                            child: SafeArea(
+                              top: true,
+                              bottom: false,
+                              child: Padding(
+                                padding: const EdgeInsets.only(top: 12),
+                                child: Column(
+                                  crossAxisAlignment:
+                                      CrossAxisAlignment.stretch,
+                                  children: [
+                                    Row(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.center,
+                                      children: [
+                                        IconButton(
+                                          icon: const Icon(Icons.arrow_back),
+                                          onPressed: updating
+                                              ? null
+                                              : () => Navigator.of(
                                                   themedPageContext,
                                                 ).maybePop(),
-                                        tooltip: MaterialLocalizations.of(
-                                                themedPageContext)
-                                            .backButtonTooltip,
-                                      ),
-                                      Expanded(
-                                        child: buildDetailHeroContent(
-                                          themedPageContext,
+                                          tooltip: MaterialLocalizations.of(
+                                            themedPageContext,
+                                          ).backButtonTooltip,
                                         ),
-                                      ),
-                                    ],
-                                  ),
-                                  if (_editMode && app != null)
-                                    _buildEditMetadataSection(
-                                      themedPageContext,
-                                      app,
-                                      appsProvider,
-                                      settingsProvider,
-                                    )
-                                  else
-                                    getInfoColumn(
-                                      themedPageContext,
-                                      small: false,
-                                    ),
-                                  Padding(
-                                    padding: const EdgeInsets.fromLTRB(
-                                        16, 0, 16, 16),
-                                    child: Row(
-                                      children: [
                                         Expanded(
-                                          child: getBottomCenterActions(
+                                          child: buildDetailHeroContent(
                                             themedPageContext,
                                           ),
                                         ),
                                       ],
                                     ),
-                                  ),
-                                  if (_editMode) const SizedBox(height: 104),
-                                  SizedBox(
-                                    height: MediaQuery.of(themedPageContext)
-                                        .padding
-                                        .bottom,
-                                  ),
-                                ],
+                                    if (_editMode && app != null)
+                                      _buildEditMetadataSection(
+                                        themedPageContext,
+                                        app,
+                                        appsProvider,
+                                        settingsProvider,
+                                      )
+                                    else
+                                      getInfoColumn(
+                                        themedPageContext,
+                                        small: false,
+                                      ),
+                                    Padding(
+                                      padding: const EdgeInsets.fromLTRB(
+                                        16,
+                                        0,
+                                        16,
+                                        16,
+                                      ),
+                                      child: Row(
+                                        children: [
+                                          Expanded(
+                                            child: getBottomCenterActions(
+                                              themedPageContext,
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                    if (_editMode) const SizedBox(height: 104),
+                                    SizedBox(
+                                      height: MediaQuery.of(
+                                        themedPageContext,
+                                      ).padding.bottom,
+                                    ),
+                                  ],
+                                ),
                               ),
                             ),
                           ),
-                        ),
-                      ],
-                    ),
-              onRefresh: () async {
-                if (_editMode) return;
-                if (app != null) {
-                  await _runCheckUpdate(app.app.id);
-                }
-              },
+                        ],
+                      ),
+                onRefresh: () async {
+                  if (_editMode) return;
+                  if (app != null) {
+                    await _runCheckUpdate(app.app.id);
+                  }
+                },
+              ),
+              bottomSheet: getBottomSheetMenu(themedPageContext),
             ),
-            bottomSheet: getBottomSheetMenu(themedPageContext),
-          ),
           );
         },
       ),

--- a/lib/pages/app.dart
+++ b/lib/pages/app.dart
@@ -2742,7 +2742,7 @@ class _AppPageState extends State<AppPage> {
       final int? knownApkSizeBytes = app?.app.apkSizeBytes;
       // Appends "· 43 MB" to install/update labels when size is known.
       String sizeAnnotated(String base) {
-        if (knownApkSizeBytes == null) {
+        if (knownApkSizeBytes == null || trackOnly) {
           return base;
         }
         return '$base · ${_formatBytes(knownApkSizeBytes)}';

--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -363,6 +363,17 @@ String trackOnlyDownloadPageUrl(App app) {
   if (changeLogValue != null &&
       (changeLogValue.startsWith('http://') ||
           changeLogValue.startsWith('https://'))) {
+    final appUrl = Uri.tryParse(app.url);
+    final changeLogUrl = Uri.tryParse(changeLogValue);
+    if (appUrl?.host.contains('apkmirror.com') == true &&
+        changeLogUrl?.host.contains('apkmirror.com') == true) {
+      final trackedPath = appUrl!.path.endsWith('/')
+          ? appUrl.path
+          : '${appUrl.path}/';
+      if (!changeLogUrl!.path.startsWith(trackedPath)) {
+        return app.url;
+      }
+    }
     return changeLogValue;
   }
   return app.url;
@@ -501,6 +512,43 @@ List<MapEntry<String, int>> moveStrToEndMapEntryWithCount(
   return arr;
 }
 
+class DownloadCancelToken {
+  bool _isCancelled = false;
+  final Set<HttpClient> _activeClients = <HttpClient>{};
+
+  bool get isCancelled {
+    return _isCancelled;
+  }
+
+  void attachClient(HttpClient client) {
+    if (_isCancelled) {
+      client.close(force: true);
+      return;
+    }
+    _activeClients.add(client);
+  }
+
+  void detachClient(HttpClient client) {
+    _activeClients.remove(client);
+  }
+
+  void cancel() {
+    _isCancelled = true;
+    final activeClientsSnapshot = _activeClients.toList();
+    _activeClients.clear();
+    for (final client in activeClientsSnapshot) {
+      client.close(force: true);
+    }
+  }
+
+  void throwIfCancelled() {
+    if (!_isCancelled) {
+      return;
+    }
+    throw ObtainiumError(tr('cancelled'));
+  }
+}
+
 Future<File> downloadFileWithRetry(
   String url,
   String fileName,
@@ -513,6 +561,7 @@ Future<File> downloadFileWithRetry(
   int retries = 3,
   bool allowInsecure = false,
   LogsProvider? logs,
+  DownloadCancelToken? cancelToken,
 }) async {
   try {
     return await downloadFile(
@@ -526,8 +575,12 @@ Future<File> downloadFileWithRetry(
       headers: headers,
       allowInsecure: allowInsecure,
       logs: logs,
+      cancelToken: cancelToken,
     );
   } catch (e) {
+    if (cancelToken?.isCancelled == true) {
+      throw ObtainiumError(tr('cancelled'));
+    }
     if (retries > 0 && e is ClientException) {
       await Future.delayed(const Duration(seconds: 5));
       return await downloadFileWithRetry(
@@ -542,6 +595,7 @@ Future<File> downloadFileWithRetry(
         retries: (retries - 1),
         allowInsecure: allowInsecure,
         logs: logs,
+        cancelToken: cancelToken,
       );
     } else {
       rethrow;
@@ -679,13 +733,19 @@ Future<File> downloadFile(
   Map<String, String>? headers,
   bool allowInsecure = false,
   LogsProvider? logs,
+  DownloadCancelToken? cancelToken,
 }) async {
   // Send the initial request but cancel it as soon as you have the headers
+  cancelToken?.throwIfCancelled();
   var reqHeaders = headers ?? {};
   var req = Request('GET', Uri.parse(url));
   req.headers.addAll(reqHeaders);
-  var headersClient = IOClient(createHttpClient(allowInsecure));
+  final headersHttpClient = createHttpClient(allowInsecure);
+  cancelToken?.attachClient(headersHttpClient);
+  var headersClient = IOClient(headersHttpClient);
   StreamedResponse headersResponse = await headersClient.send(req);
+  cancelToken?.detachClient(headersHttpClient);
+  cancelToken?.throwIfCancelled();
   var resHeaders = headersResponse.headers;
 
   // Use the headers to decide what the file extension is, and
@@ -749,7 +809,9 @@ Future<File> downloadFile(
     int currentTempFileSize = await tempDownloadedFile.length();
     bool shouldReturn = false;
     while (isDownloading) {
+      cancelToken?.throwIfCancelled();
       await Future.delayed(Duration(seconds: 7));
+      cancelToken?.throwIfCancelled();
       if (tempDownloadedFile.existsSync()) {
         int newTempFileSize = await tempDownloadedFile.length();
         if (newTempFileSize > currentTempFileSize) {
@@ -803,6 +865,8 @@ Future<File> downloadFile(
   );
   HttpClient responseClient = responseWithClient.value.key;
   HttpClientResponse response = responseWithClient.value.value;
+  cancelToken?.attachClient(responseClient);
+  cancelToken?.throwIfCancelled();
   sink ??= tempDownloadedFile.openWrite(mode: FileMode.writeOnly);
 
   // Perform the download
@@ -815,40 +879,54 @@ Future<File> downloadFile(
   const downloadUIUpdateInterval = Duration(milliseconds: 500);
   const downloadBufferSize = 32 * 1024; // 32KB
   final downloadBuffer = BytesBuilder();
-  await response
-      .asBroadcastStream()
-      .map((chunk) {
-        received += chunk.length;
-        final now = DateTime.now();
-        if (onProgress != null &&
-            (lastProgressUpdate == null ||
-                now.difference(lastProgressUpdate!) >=
-                    downloadUIUpdateInterval)) {
-          progress = fullContentLength != null
-              ? clampDouble((received / fullContentLength) * 100, 0, 100)
-              : 30;
-          onProgress(progress);
-          lastProgressUpdate = now;
-        }
-        return chunk;
-      })
-      .transform(
-        StreamTransformer<List<int>, List<int>>.fromHandlers(
-          handleData: (List<int> data, EventSink<List<int>> s) {
-            downloadBuffer.add(data);
-            if (downloadBuffer.length >= downloadBufferSize) {
-              s.add(downloadBuffer.takeBytes());
-            }
-          },
-          handleDone: (EventSink<List<int>> s) {
-            if (downloadBuffer.isNotEmpty) {
-              s.add(downloadBuffer.takeBytes());
-            }
-            s.close();
-          },
-        ),
-      )
-      .pipe(sink);
+  try {
+    await response
+        .asBroadcastStream()
+        .map((chunk) {
+          cancelToken?.throwIfCancelled();
+          received += chunk.length;
+          final now = DateTime.now();
+          if (onProgress != null &&
+              (lastProgressUpdate == null ||
+                  now.difference(lastProgressUpdate!) >=
+                      downloadUIUpdateInterval)) {
+            progress = fullContentLength != null
+                ? clampDouble((received / fullContentLength) * 100, 0, 100)
+                : 30;
+            onProgress(progress);
+            lastProgressUpdate = now;
+          }
+          return chunk;
+        })
+        .transform(
+          StreamTransformer<List<int>, List<int>>.fromHandlers(
+            handleData: (List<int> data, EventSink<List<int>> sink) {
+              downloadBuffer.add(data);
+              if (downloadBuffer.length >= downloadBufferSize) {
+                sink.add(downloadBuffer.takeBytes());
+              }
+            },
+            handleDone: (EventSink<List<int>> sink) {
+              if (downloadBuffer.isNotEmpty) {
+                sink.add(downloadBuffer.takeBytes());
+              }
+              sink.close();
+            },
+          ),
+        )
+        .pipe(sink);
+  } catch (_) {
+    responseClient.close(force: true);
+    if (cancelToken?.isCancelled == true) {
+      if (tempDownloadedFile.existsSync()) {
+        deleteFile(tempDownloadedFile);
+      }
+      throw ObtainiumError(tr('cancelled'));
+    }
+    rethrow;
+  } finally {
+    cancelToken?.detachClient(responseClient);
+  }
   await sink.close();
   progress = null;
   if (onProgress != null) {
@@ -932,6 +1010,7 @@ class AppsProvider with ChangeNotifier {
   // Debounce timer for download-progress notifications so widgets that watch
   // the whole provider (e.g. AppPage) don't get hammered on every byte chunk.
   Timer? _progressNotifyTimer;
+  final Map<String, DownloadCancelToken> _downloadCancelTokens = {};
 
   /// Remove-from-Obtainium was confirmed without uninstall: JSON is stashed, UI updates,
   /// and disk is purged after 5s unless the user undoes.
@@ -951,6 +1030,10 @@ class AppsProvider with ChangeNotifier {
   late SettingsProvider settingsProvider;
 
   Iterable<AppInMemory> getAppValues() => apps.values.map((a) => a.deepCopy());
+
+  void cancelDownload(String appId) {
+    _downloadCancelTokens[appId]?.cancel();
+  }
 
   AppsProvider({bool isBg = false, SettingsProvider? sharedSettings}) {
     settingsProvider = sharedSettings ?? SettingsProvider();
@@ -1068,6 +1151,9 @@ class AppsProvider with ChangeNotifier {
       notifyListeners();
     }
     bool downloadSucceeded = false;
+    final cancelToken = DownloadCancelToken();
+    _downloadCancelTokens[app.id]?.cancel();
+    _downloadCancelTokens[app.id] = cancelToken;
     try {
       AppSource source = SourceProvider().getSource(
         app.url,
@@ -1133,6 +1219,7 @@ class AppsProvider with ChangeNotifier {
         useExisting: useExisting,
         allowInsecure: app.additionalSettings['allowInsecure'] == true,
         logs: logs,
+        cancelToken: cancelToken,
       );
       // Set to 90 for remaining steps, will make null in 'finally'
       if (apps[app.id] != null) {
@@ -1231,6 +1318,9 @@ class AppsProvider with ChangeNotifier {
         );
       }
     } finally {
+      if (identical(_downloadCancelTokens[app.id], cancelToken)) {
+        _downloadCancelTokens.remove(app.id);
+      }
       _progressNotifyTimer?.cancel();
       notificationsProvider?.cancel(notifId);
       if (apps[app.id] != null) {
@@ -3417,6 +3507,10 @@ class AppsProvider with ChangeNotifier {
 
   @override
   void dispose() {
+    for (final cancelToken in _downloadCancelTokens.values) {
+      cancelToken.cancel();
+    }
+    _downloadCancelTokens.clear();
     _progressNotifyTimer?.cancel();
     for (final Timer timer in _deferredObtainiumTimers.values) {
       timer.cancel();

--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -900,17 +900,17 @@ Future<File> downloadFile(
         })
         .transform(
           StreamTransformer<List<int>, List<int>>.fromHandlers(
-            handleData: (List<int> data, EventSink<List<int>> sink) {
+            handleData: (List<int> data, EventSink<List<int>> eventSink) {
               downloadBuffer.add(data);
               if (downloadBuffer.length >= downloadBufferSize) {
-                sink.add(downloadBuffer.takeBytes());
+                eventSink.add(downloadBuffer.takeBytes());
               }
             },
-            handleDone: (EventSink<List<int>> sink) {
+            handleDone: (EventSink<List<int>> eventSink) {
               if (downloadBuffer.isNotEmpty) {
-                sink.add(downloadBuffer.takeBytes());
+                eventSink.add(downloadBuffer.takeBytes());
               }
-              sink.close();
+              eventSink.close();
             },
           ),
         )

--- a/lib/services/bulk_import_service.dart
+++ b/lib/services/bulk_import_service.dart
@@ -13,7 +13,8 @@ import 'package:obtainium/app_sources/github.dart';
 import 'package:obtainium/providers/settings_provider.dart';
 
 const int _flagSystem = 1; // ApplicationInfo.FLAG_SYSTEM = 0x1
-const int _flagUpdatedSystemApp = 128; // ApplicationInfo.FLAG_UPDATED_SYSTEM_APP = 0x80
+const int _flagUpdatedSystemApp =
+    128; // ApplicationInfo.FLAG_UPDATED_SYSTEM_APP = 0x80
 
 class InstalledAppInfo {
   final String packageName;
@@ -49,6 +50,12 @@ class InstalledAppInfo {
 
 class BulkImportService {
   static final _pm = AndroidPackageManager();
+  static const Map<String, String> _apkMirrorPreferredPackageUrls = {
+    // APKMirror's app_exists endpoint can return Wear OS / Android Automotive
+    // sibling listings for this shared package ID. Prefer the phone listing.
+    'com.google.android.apps.youtube.music':
+        'https://www.apkmirror.com/apk/google-inc/youtube-music/',
+  };
 
   /// Returns all installed apps, filtered by system/user.
   static Future<List<InstalledAppInfo>> getInstalledApps({
@@ -77,10 +84,12 @@ class BulkImportService {
 
     // Fetch all app labels concurrently instead of sequentially.
     final names = await Future.wait(
-      filtered.map((pkg) async =>
-          await pkg.applicationInfo?.getAppLabel() ??
-          pkg.applicationInfo?.processName ??
-          (pkg.packageName as String)),
+      filtered.map(
+        (pkg) async =>
+            await pkg.applicationInfo?.getAppLabel() ??
+            pkg.applicationInfo?.processName ??
+            (pkg.packageName as String),
+      ),
     );
 
     final result = <InstalledAppInfo>[
@@ -128,7 +137,9 @@ class BulkImportService {
     if (alreadyKnown != null) {
       for (final String packageName in packageNames) {
         if (alreadyKnown.containsKey(packageName)) {
-          result[packageName] = alreadyKnown[packageName];
+          result[packageName] =
+              _apkMirrorPreferredPackageUrls[packageName] ??
+              alreadyKnown[packageName];
         }
       }
     }
@@ -156,10 +167,7 @@ class BulkImportService {
       if (shouldAbort?.call() == true) {
         return result;
       }
-      final batch = toQuery.sublist(
-        i,
-        min(i + batchSize, toQuery.length),
-      );
+      final batch = toQuery.sublist(i, min(i + batchSize, toQuery.length));
       try {
         final response = await http
             .post(
@@ -187,7 +195,9 @@ class BulkImportService {
             // app.link is a relative path like /apk/google-inc/google-maps/
             final appLink = item['app']?['link'] as String?;
             if (pname != null && exists && appLink != null) {
-              result[pname] = 'https://www.apkmirror.com$appLink';
+              result[pname] =
+                  _apkMirrorPreferredPackageUrls[pname] ??
+                  'https://www.apkmirror.com$appLink';
             } else if (pname != null) {
               result[pname] = null;
             }
@@ -261,48 +271,55 @@ class BulkImportService {
     for (int i = 0; i < toQuery.length; i += concurrency) {
       if (shouldAbort?.call() == true) return result;
       final chunk = toQuery.sublist(i, min(i + concurrency, toQuery.length));
-      for (int subStart = 0; subStart < chunk.length; subStart += subBatchSize) {
+      for (
+        int subStart = 0;
+        subStart < chunk.length;
+        subStart += subBatchSize
+      ) {
         if (shouldAbort?.call() == true) return result;
         final subChunk = chunk.sublist(
           subStart,
           min(subStart + subBatchSize, chunk.length),
         );
-        await Future.wait(subChunk.map((pkg) async {
-          try {
-            final response = await http
-                .get(
-                  Uri.parse(
-                    'https://tapi.pureapk.com/v3/get_app_his_version'
-                    '?package_name=$pkg&hl=en',
-                  ),
-                  headers: headers,
-                )
-                .timeout(const Duration(seconds: 15));
+        await Future.wait(
+          subChunk.map((pkg) async {
+            try {
+              final response = await http
+                  .get(
+                    Uri.parse(
+                      'https://tapi.pureapk.com/v3/get_app_his_version'
+                      '?package_name=$pkg&hl=en',
+                    ),
+                    headers: headers,
+                  )
+                  .timeout(const Duration(seconds: 15));
 
-            if (response.statusCode == 200) {
-              final body = jsonDecode(response.body);
-              final List<dynamic> versions = body is Map
-                  ? (body['version_list'] as List? ?? [])
-                  : [];
-              if (versions.isNotEmpty) {
-                final first = versions.first;
-                final appName =
-                    first is Map ? (first['title'] as String? ?? '') : '';
-                result[pkg] = appName.isNotEmpty
-                    ? 'https://apkpure.net/${_slugify(appName)}/$pkg'
-                    : 'https://apkpure.net/$pkg';
+              if (response.statusCode == 200) {
+                final body = jsonDecode(response.body);
+                final List<dynamic> versions = body is Map
+                    ? (body['version_list'] as List? ?? [])
+                    : [];
+                if (versions.isNotEmpty) {
+                  final first = versions.first;
+                  final appName = first is Map
+                      ? (first['title'] as String? ?? '')
+                      : '';
+                  result[pkg] = appName.isNotEmpty
+                      ? 'https://apkpure.net/${_slugify(appName)}/$pkg'
+                      : 'https://apkpure.net/$pkg';
+                } else {
+                  result[pkg] = null;
+                }
               } else {
-                result[pkg] = null;
+                // Non-200 — don't cache; retry next scan.
               }
-            } else {
-              // Non-200 — don't cache; retry next scan.
+            } catch (e) {
+              debugPrint('APKPure check failed for $pkg: $e');
+              // Network error or timeout — don't cache; retry next scan.
             }
-          } catch (e) {
-            debugPrint('APKPure check failed for $pkg: $e');
-            // Network error or timeout — don't cache; retry next scan.
-          }
-          reportProgress();
-        }));
+            reportProgress();
+          }),
+        );
         if (shouldAbort?.call() == true) return result;
       }
     }
@@ -314,7 +331,8 @@ class BulkImportService {
   /// share this [IOClient] with a raised [HttpClient.maxConnectionsPerHost] and
   /// one [Future.wait] per chunk of [_bulkPackageApiChunkSize] packages.
   static const int _bulkPackageApiChunkSize = 20;
-  static const int _bulkPackageApiMaxConnectionsPerHost = _bulkPackageApiChunkSize;
+  static const int _bulkPackageApiMaxConnectionsPerHost =
+      _bulkPackageApiChunkSize;
 
   /// Ensures [recordStoreCoverage] sees every package (null means not in store).
   static void _putMissingPackageKeysAsNull(
@@ -333,7 +351,7 @@ class BulkImportService {
     void Function(int done, int total)? onProgress,
     bool Function()? shouldAbort,
     required Future<void> Function(http.Client client, String packageName)
-        runLookup,
+    runLookup,
   }) async {
     int finishedAttempts = result.length;
     void reportAttemptProgress() {
@@ -346,9 +364,11 @@ class BulkImportService {
       ..maxConnectionsPerHost = _bulkPackageApiMaxConnectionsPerHost;
     final http.Client client = IOClient(rawHttpClient);
     try {
-      for (int chunkStart = 0;
-          chunkStart < toQuery.length;
-          chunkStart += _bulkPackageApiChunkSize) {
+      for (
+        int chunkStart = 0;
+        chunkStart < toQuery.length;
+        chunkStart += _bulkPackageApiChunkSize
+      ) {
         if (shouldAbort?.call() == true) {
           return;
         }
@@ -356,16 +376,18 @@ class BulkImportService {
           chunkStart,
           min(chunkStart + _bulkPackageApiChunkSize, toQuery.length),
         );
-        await Future.wait(chunk.map((String pkg) async {
-          try {
-            await runLookup(client, pkg);
-          } catch (_) {
-            //
-          } finally {
-            finishedAttempts++;
-            reportAttemptProgress();
-          }
-        }));
+        await Future.wait(
+          chunk.map((String pkg) async {
+            try {
+              await runLookup(client, pkg);
+            } catch (_) {
+              //
+            } finally {
+              finishedAttempts++;
+              reportAttemptProgress();
+            }
+          }),
+        );
         if (shouldAbort?.call() == true) {
           return;
         }
@@ -433,13 +455,16 @@ class BulkImportService {
 
   /// Picks the suggested APK filename for an `<application>` from [index.xml].
   static String? _izzyApkStoreUrlFromIndexApplication(html_dom.Element app) {
-    final List<html_dom.Element> packageElements =
-        app.getElementsByTagName('package');
+    final List<html_dom.Element> packageElements = app.getElementsByTagName(
+      'package',
+    );
     if (packageElements.isEmpty) {
       return null;
     }
-    final String? marketVerCodeText =
-        app.querySelector('marketvercode')?.innerHtml.trim();
+    final String? marketVerCodeText = app
+        .querySelector('marketvercode')
+        ?.innerHtml
+        .trim();
     final int? marketVerCode = int.tryParse(marketVerCodeText ?? '');
     html_dom.Element? selectedPackage;
     if (marketVerCode != null) {
@@ -449,8 +474,10 @@ class BulkImportService {
             ?.innerHtml
             .trim();
         final int? versionCode = int.tryParse(versionCodeText ?? '');
-        final String? apkName =
-            packageElement.querySelector('apkname')?.innerHtml.trim();
+        final String? apkName = packageElement
+            .querySelector('apkname')
+            ?.innerHtml
+            .trim();
         if (versionCode == marketVerCode &&
             apkName != null &&
             apkName.isNotEmpty) {
@@ -466,10 +493,11 @@ class BulkImportService {
             .querySelector('versioncode')
             ?.innerHtml
             .trim();
-        final int versionCode =
-            int.tryParse(versionCodeText ?? '') ?? -1;
-        final String? apkName =
-            packageElement.querySelector('apkname')?.innerHtml.trim();
+        final int versionCode = int.tryParse(versionCodeText ?? '') ?? -1;
+        final String? apkName = packageElement
+            .querySelector('apkname')
+            ?.innerHtml
+            .trim();
         if (apkName != null &&
             apkName.isNotEmpty &&
             versionCode > bestVersionCode) {
@@ -478,8 +506,10 @@ class BulkImportService {
         }
       }
     }
-    final String? apkName =
-        selectedPackage?.querySelector('apkname')?.innerHtml.trim();
+    final String? apkName = selectedPackage
+        ?.querySelector('apkname')
+        ?.innerHtml
+        .trim();
     if (apkName == null || !apkName.toLowerCase().endsWith('.apk')) {
       return null;
     }
@@ -487,17 +517,21 @@ class BulkImportService {
   }
 
   /// Isolate entry for [compute]; must stay in sync with [_izzyApkStoreUrlFromIndexApplication].
-  static Map<String, String> _izzyIndexBodyToPackageStoreUrls(String indexBody) {
+  static Map<String, String> _izzyIndexBodyToPackageStoreUrls(
+    String indexBody,
+  ) {
     final html_dom.Document document = parse(indexBody);
     final Map<String, String> packageIdToStoreUrl = <String, String>{};
-    for (final html_dom.Element applicationElement
-        in document.querySelectorAll('application')) {
+    for (final html_dom.Element applicationElement in document.querySelectorAll(
+      'application',
+    )) {
       final String? applicationId = applicationElement.attributes['id'];
       if (applicationId == null || applicationId.isEmpty) {
         continue;
       }
-      final String? storeUrl =
-          _izzyApkStoreUrlFromIndexApplication(applicationElement);
+      final String? storeUrl = _izzyApkStoreUrlFromIndexApplication(
+        applicationElement,
+      );
       if (storeUrl != null) {
         packageIdToStoreUrl[applicationId] = storeUrl;
       }
@@ -562,8 +596,10 @@ class BulkImportService {
       }
       onProgress?.call(result.length, packageNames.length);
 
-      final Map<String, String> packageIdToStoreUrl =
-          await compute(_izzyIndexBodyToPackageStoreUrls, indexResponse.body);
+      final Map<String, String> packageIdToStoreUrl = await compute(
+        _izzyIndexBodyToPackageStoreUrls,
+        indexResponse.body,
+      );
 
       onProgress?.call(result.length, packageNames.length);
 
@@ -609,8 +645,8 @@ class BulkImportService {
           if (response.statusCode == 200) {
             try {
               final dynamic decoded = jsonDecode(response.body);
-              String? versionCodeStr =
-                  decoded['suggestedVersionCode']?.toString();
+              String? versionCodeStr = decoded['suggestedVersionCode']
+                  ?.toString();
               if (versionCodeStr == null || versionCodeStr.isEmpty) {
                 final List<dynamic>? packages =
                     decoded['packages'] as List<dynamic>?;
@@ -681,15 +717,17 @@ class BulkImportService {
       'Accept': 'application/vnd.github.v3+json',
       'User-Agent': 'ObtainX-BulkImport',
     };
-    final Map<String, String>? authHeaders = await githubSource.getRequestHeaders(
-      <String, dynamic>{},
-      'https://api.github.com/search/code',
-    );
+    final Map<String, String>? authHeaders = await githubSource
+        .getRequestHeaders(
+          <String, dynamic>{},
+          'https://api.github.com/search/code',
+        );
     if (authHeaders != null) {
       headers.addAll(authHeaders);
     }
     final bool hasAuthToken =
-        headers.containsKey('Authorization') || headers.containsKey('authorization');
+        headers.containsKey('Authorization') ||
+        headers.containsKey('authorization');
 
     for (final String pkg in toQuery) {
       if (shouldAbort?.call() == true) {
@@ -706,10 +744,9 @@ class BulkImportService {
             'per_page': '15',
           },
         );
-        final http.Response response =
-            await http.get(uri, headers: headers).timeout(
-                  const Duration(seconds: 25),
-                );
+        final http.Response response = await http
+            .get(uri, headers: headers)
+            .timeout(const Duration(seconds: 25));
         if (response.statusCode == 200) {
           final Object? decoded = jsonDecode(response.body);
           if (decoded is Map<String, dynamic>) {
@@ -718,8 +755,7 @@ class BulkImportService {
             String? chosenUrl;
             for (final dynamic raw in items) {
               if (raw is! Map<String, dynamic>) continue;
-              final String path =
-                  (raw['path'] as String? ?? '').toLowerCase();
+              final String path = (raw['path'] as String? ?? '').toLowerCase();
               final Object? repo = raw['repository'];
               if (repo is! Map<String, dynamic>) continue;
               final String? htmlUrl = repo['html_url'] as String?;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.5.0+3500
+version: 2.5.1+3510
 
 environment:
   sdk: ^3.10.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.4.4+3440
+version: 2.5.0+3500
 
 environment:
   sdk: ^3.10.0

--- a/test/version_order_test.dart
+++ b/test/version_order_test.dart
@@ -1,22 +1,57 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart';
+import 'package:obtainium/app_sources/fdroid.dart';
 import 'package:obtainium/providers/apps_provider.dart';
 
 void main() {
   test(
     'semver with parenthetical decimal build is not version order unclear',
     () {
+      expect(versionOrderIsUnclear('8.8 (88957691)', '8.6 (86672232)'), false);
       expect(
-        versionOrderIsUnclear('8.8 (88957691)', '8.6 (86672232)'),
-        false,
+        compareVersionsByNumericSegments('8.8 (88957691)', '8.6 (86672232)'),
+        1,
       );
-      expect(compareVersionsByNumericSegments('8.8 (88957691)', '8.6 (86672232)'), 1);
     },
   );
 
-  test('real hex in version string still participates in versionsEffectivelyEqual', () {
+  test(
+    'real hex in version string still participates in versionsEffectivelyEqual',
+    () {
+      expect(
+        versionsEffectivelyEqual('1.5.3-DEV (75094D8)', 'debug-75094d8'),
+        true,
+      );
+    },
+  );
+
+  test('f-droid regex version filter keeps newest matching release', () async {
+    final details = await FDroid().getAPKUrlsFromFDroidPackagesAPIResponse(
+      Response('''
+{
+  "packageName": "org.torproject.vpn",
+  "packages": [
+    {"versionName": "1.6.0Beta-x86_64", "versionCode": 204},
+    {"versionName": "1.6.0Beta-x86", "versionCode": 203},
+    {"versionName": "1.6.0Beta-arm64-v8a", "versionCode": 202},
+    {"versionName": "1.6.0Beta-armeabi-v7a", "versionCode": 201},
+    {"versionName": "1.5.0Beta-x86_64", "versionCode": 194},
+    {"versionName": "1.5.0Beta-x86", "versionCode": 193},
+    {"versionName": "1.5.0Beta-arm64-v8a", "versionCode": 192},
+    {"versionName": "1.5.0Beta-armeabi-v7a", "versionCode": 191}
+  ]
+}
+''', 200),
+      'http://127.0.0.1:1/repo/org.torproject.vpn',
+      'https://f-droid.org/packages/org.torproject.vpn/',
+      'F-Droid',
+      additionalSettings: {'filterVersionsByRegEx': 'arm64'},
+    );
+
+    expect(details.version, '1.6.0Beta-arm64-v8a');
     expect(
-      versionsEffectivelyEqual('1.5.3-DEV (75094D8)', 'debug-75094d8'),
-      true,
+      details.apkUrls.single.value,
+      'http://127.0.0.1:1/repo/org.torproject.vpn_202.apk',
     );
   });
 }


### PR DESCRIPTION
## ✨ New Features
- Shows APK size on install/update actions when source metadata provides it.
- Adds live download byte progress and a cancel action on the app detail page.
- Extends APK size detection to APKMirror, APKPure, Aptoide, F-Droid, and third-party F-Droid repos.
- Adds IzzyOnDroid as a searchable source on the app search page and device page via a dedicated store button. 

## 🚀 Improved Features
- Improves APKMirror track-only handling with better release page matching, download page detection, icon discovery, and YouTube Music URL alias normalization.
- Improves bulk store discovery by making F-Droid-style lookups more parallel and adding faster IzzyOnDroid index-based lookup with API fallback.

## 🐛 Bug Fixes
- Fixes F-Droid regex version filtering so it keeps the newest matching release instead of accidentally selecting an older matching variant.
- Prevents APKMirror track-only links from opening release pages outside the tracked app path.
- Cleans up partial downloads correctly when a download is cancelled.

## 🧰 Others
- Adds test coverage for F-Droid regex filtering and preserves existing version comparison behavior.