### PR TITLE
Remember folders, keep-awake during downloads, faster update check, settings tonal pill 

### DIFF
--- a/android/app/src/main/kotlin/dev/imranr/obtainium/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/imranr/obtainium/MainActivity.kt
@@ -12,9 +12,11 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.drawable.BitmapDrawable
 import android.net.Uri
+import android.net.wifi.WifiManager
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.os.PowerManager
 import android.os.SystemClock
 import android.system.Os
 import io.flutter.embedding.android.FlutterActivity
@@ -26,6 +28,9 @@ import java.util.UUID
 
 private const val CHANNEL = "dev.imranr.obtainium/installer"
 private const val DEVICE_APPS_CHANNEL = "dev.imranr.obtainium/device_apps"
+private const val POWER_CHANNEL = "dev.imranr.obtainium/power"
+private const val DOWNLOAD_WAKE_LOCK_TAG = "ObtainX:DownloadWakeLock"
+private const val DOWNLOAD_WIFI_LOCK_TAG = "ObtainX:DownloadWifiLock"
 private const val APK_MIME = "application/vnd.android.package-archive"
 private const val RELEASE_DIR = "releases"
 private const val INSTALL_TIMEOUT_MS = 120_000L
@@ -55,6 +60,9 @@ class MainActivity : FlutterActivity() {
     }
 
     private var installWatcher: InstallWatcher? = null
+    private var downloadKeepAwakeCount = 0
+    private var downloadWakeLock: PowerManager.WakeLock? = null
+    private var downloadWifiLock: WifiManager.WifiLock? = null
 
     private fun completeThirdPartyInstallSession(watcher: InstallWatcher, outcome: InstallSessionOutcome) {
         if (watcher.responded) return
@@ -144,6 +152,93 @@ class MainActivity : FlutterActivity() {
                 else -> result.notImplemented()
             }
         }
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            POWER_CHANNEL,
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "acquireDownloadKeepAwake" -> {
+                    result.success(acquireDownloadKeepAwake())
+                }
+                "releaseDownloadKeepAwake" -> {
+                    releaseDownloadKeepAwake()
+                    result.success(null)
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun acquireDownloadKeepAwake(): Boolean {
+        var acquiredWakeLock: PowerManager.WakeLock? = null
+        var acquiredWifiLock: WifiManager.WifiLock? = null
+        return try {
+            if (downloadWakeLock?.isHeld != true) {
+                val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
+                acquiredWakeLock = powerManager.newWakeLock(
+                    PowerManager.PARTIAL_WAKE_LOCK,
+                    DOWNLOAD_WAKE_LOCK_TAG,
+                ).apply {
+                    setReferenceCounted(false)
+                    acquire()
+                }
+            }
+
+            if (downloadWifiLock?.isHeld != true) {
+                val wifiManager = applicationContext.getSystemService(Context.WIFI_SERVICE) as? WifiManager
+                    ?: throw IllegalStateException("Wifi service unavailable")
+                acquiredWifiLock = wifiManager.createWifiLock(
+                    WifiManager.WIFI_MODE_FULL_HIGH_PERF,
+                    DOWNLOAD_WIFI_LOCK_TAG,
+                ).apply {
+                    setReferenceCounted(false)
+                    acquire()
+                }
+            }
+
+            if (acquiredWakeLock != null) {
+                downloadWakeLock = acquiredWakeLock
+            }
+            if (acquiredWifiLock != null) {
+                downloadWifiLock = acquiredWifiLock
+            }
+            downloadKeepAwakeCount += 1
+            true
+        } catch (_: Exception) {
+            try {
+                if (acquiredWifiLock?.isHeld == true) {
+                    acquiredWifiLock.release()
+                }
+            } catch (_: Exception) { }
+            try {
+                if (acquiredWakeLock?.isHeld == true) {
+                    acquiredWakeLock.release()
+                }
+            } catch (_: Exception) { }
+            false
+        }
+    }
+
+    private fun releaseDownloadKeepAwake() {
+        if (downloadKeepAwakeCount > 0) {
+            downloadKeepAwakeCount -= 1
+        }
+        if (downloadKeepAwakeCount > 0) return
+
+        try {
+            if (downloadWifiLock?.isHeld == true) {
+                downloadWifiLock?.release()
+            }
+        } catch (_: Exception) { }
+        downloadWifiLock = null
+
+        try {
+            if (downloadWakeLock?.isHeld == true) {
+                downloadWakeLock?.release()
+            }
+        } catch (_: Exception) { }
+        downloadWakeLock = null
     }
 
     @Suppress("DEPRECATION")

--- a/android/app/src/main/kotlin/dev/imranr/obtainium/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/imranr/obtainium/MainActivity.kt
@@ -1,5 +1,6 @@
 package dev.imranr.obtainium
 
+import android.app.Activity
 import android.content.BroadcastReceiver
 import android.content.ClipData
 import android.content.ComponentName
@@ -18,6 +19,7 @@ import android.os.Handler
 import android.os.Looper
 import android.os.PowerManager
 import android.os.SystemClock
+import android.provider.DocumentsContract
 import android.system.Os
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
@@ -29,11 +31,13 @@ import java.util.UUID
 private const val CHANNEL = "dev.imranr.obtainium/installer"
 private const val DEVICE_APPS_CHANNEL = "dev.imranr.obtainium/device_apps"
 private const val POWER_CHANNEL = "dev.imranr.obtainium/power"
+private const val STORAGE_CHANNEL = "dev.imranr.obtainium/storage"
 private const val DOWNLOAD_WAKE_LOCK_TAG = "ObtainX:DownloadWakeLock"
 private const val DOWNLOAD_WIFI_LOCK_TAG = "ObtainX:DownloadWifiLock"
 private const val APK_MIME = "application/vnd.android.package-archive"
 private const val RELEASE_DIR = "releases"
 private const val INSTALL_TIMEOUT_MS = 120_000L
+private const val OPEN_PERSISTED_DOCUMENT_TREE_REQUEST_CODE = 5107
 /// Ignore focus regain cancel if we lost focus more recently than this (transition bounce).
 private const val FOCUS_REGAIN_CANCEL_MIN_MS = 200L
 
@@ -64,6 +68,7 @@ class MainActivity : FlutterActivity() {
     private var downloadKeepAwakeCount = 0
     private var downloadWakeLock: PowerManager.WakeLock? = null
     private var downloadWifiLock: WifiManager.WifiLock? = null
+    private var openPersistedDocumentTreeResult: MethodChannel.Result? = null
 
     private fun completeThirdPartyInstallSession(watcher: InstallWatcher, outcome: InstallSessionOutcome) {
         if (watcher.responded) return
@@ -167,6 +172,83 @@ class MainActivity : FlutterActivity() {
                 }
                 else -> result.notImplemented()
             }
+        }
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            STORAGE_CHANNEL,
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "openPersistedDocumentTree" -> {
+                    openPersistedDocumentTree(call.argument<String>("initialUri"), result)
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    private fun openPersistedDocumentTree(initialUri: String?, result: MethodChannel.Result) {
+        if (openPersistedDocumentTreeResult != null) {
+            result.error("PICKER_ACTIVE", "A document tree picker is already active.", null)
+            return
+        }
+
+        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+            addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
+            addFlags(Intent.FLAG_GRANT_PREFIX_URI_PERMISSION)
+            if (!initialUri.isNullOrBlank() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                putExtra(DocumentsContract.EXTRA_INITIAL_URI, Uri.parse(initialUri))
+            }
+        }
+
+        openPersistedDocumentTreeResult = result
+        try {
+            startActivityForResult(intent, OPEN_PERSISTED_DOCUMENT_TREE_REQUEST_CODE)
+        } catch (ex: Exception) {
+            openPersistedDocumentTreeResult = null
+            result.error("OPEN_TREE_FAILED", ex.message, null)
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if (requestCode != OPEN_PERSISTED_DOCUMENT_TREE_REQUEST_CODE) {
+            super.onActivityResult(requestCode, resultCode, data)
+            return
+        }
+
+        val pendingResult = openPersistedDocumentTreeResult ?: return
+        openPersistedDocumentTreeResult = null
+
+        if (resultCode != Activity.RESULT_OK) {
+            pendingResult.success(null)
+            return
+        }
+
+        val uri = data?.data
+        if (uri == null) {
+            pendingResult.success(null)
+            return
+        }
+
+        val permissionFlags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+        val grantedPermissionFlags = data.flags and permissionFlags
+        if (grantedPermissionFlags != permissionFlags) {
+            pendingResult.error(
+                "PERSIST_TREE_PERMISSION_FAILED",
+                "The selected folder did not grant read and write permissions.",
+                null,
+            )
+            return
+        }
+        try {
+            contentResolver.takePersistableUriPermission(
+                uri,
+                grantedPermissionFlags,
+            )
+            pendingResult.success(uri.toString())
+        } catch (ex: Exception) {
+            pendingResult.error("PERSIST_TREE_PERMISSION_FAILED", ex.message, null)
         }
     }
 

--- a/android/app/src/main/kotlin/dev/imranr/obtainium/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/imranr/obtainium/MainActivity.kt
@@ -60,6 +60,7 @@ class MainActivity : FlutterActivity() {
     }
 
     private var installWatcher: InstallWatcher? = null
+    private val downloadKeepAwakeLock = Any()
     private var downloadKeepAwakeCount = 0
     private var downloadWakeLock: PowerManager.WakeLock? = null
     private var downloadWifiLock: WifiManager.WifiLock? = null
@@ -170,10 +171,10 @@ class MainActivity : FlutterActivity() {
     }
 
     @Suppress("DEPRECATION")
-    private fun acquireDownloadKeepAwake(): Boolean {
+    private fun acquireDownloadKeepAwake(): Boolean = synchronized(downloadKeepAwakeLock) {
         var acquiredWakeLock: PowerManager.WakeLock? = null
         var acquiredWifiLock: WifiManager.WifiLock? = null
-        return try {
+        try {
             if (downloadWakeLock?.isHeld != true) {
                 val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
                 acquiredWakeLock = powerManager.newWakeLock(
@@ -221,24 +222,26 @@ class MainActivity : FlutterActivity() {
     }
 
     private fun releaseDownloadKeepAwake() {
-        if (downloadKeepAwakeCount > 0) {
-            downloadKeepAwakeCount -= 1
+        synchronized(downloadKeepAwakeLock) {
+            if (downloadKeepAwakeCount > 0) {
+                downloadKeepAwakeCount -= 1
+            }
+            if (downloadKeepAwakeCount > 0) return@synchronized
+
+            try {
+                if (downloadWifiLock?.isHeld == true) {
+                    downloadWifiLock?.release()
+                }
+            } catch (_: Exception) { }
+            downloadWifiLock = null
+
+            try {
+                if (downloadWakeLock?.isHeld == true) {
+                    downloadWakeLock?.release()
+                }
+            } catch (_: Exception) { }
+            downloadWakeLock = null
         }
-        if (downloadKeepAwakeCount > 0) return
-
-        try {
-            if (downloadWifiLock?.isHeld == true) {
-                downloadWifiLock?.release()
-            }
-        } catch (_: Exception) { }
-        downloadWifiLock = null
-
-        try {
-            if (downloadWakeLock?.isHeld == true) {
-                downloadWakeLock?.release()
-            }
-        } catch (_: Exception) { }
-        downloadWakeLock = null
     }
 
     @Suppress("DEPRECATION")

--- a/android/app/src/main/kotlin/dev/imranr/obtainium/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/imranr/obtainium/MainActivity.kt
@@ -181,8 +181,25 @@ class MainActivity : FlutterActivity() {
                 "openPersistedDocumentTree" -> {
                     openPersistedDocumentTree(call.argument<String>("initialUri"), result)
                 }
+                "hasPersistedDocumentTreePermission" -> {
+                    result.success(
+                        hasPersistedDocumentTreePermission(call.argument<String>("uri")),
+                    )
+                }
                 else -> result.notImplemented()
             }
+        }
+    }
+
+    private fun hasPersistedDocumentTreePermission(uriString: String?): Boolean {
+        if (uriString.isNullOrBlank()) {
+            return false
+        }
+        val uri = Uri.parse(uriString)
+        return contentResolver.persistedUriPermissions.any { persistedPermission ->
+            persistedPermission.uri == uri &&
+                persistedPermission.isReadPermission &&
+                persistedPermission.isWritePermission
         }
     }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -153,6 +153,9 @@ void main() async {
   }
   final SettingsProvider settingsProvider = SettingsProvider();
   await settingsProvider.initializeSettings();
+  if (settingsProvider.useSystemFont) {
+    await NativeFeatures.loadSystemFont();
+  }
   final np = NotificationsProvider();
   await np.initialize();
   FlutterForegroundTask.initCommunicationPort();
@@ -420,8 +423,6 @@ class _ObtainiumState extends State<Obtainium> {
           if (settingsProvider.useBlackTheme) {
             darkColorScheme = darkColorScheme.withPureBlackBackgrounds();
           }
-
-          if (settingsProvider.useSystemFont) NativeFeatures.loadSystemFont();
 
           final ColorScheme themeColorScheme =
               settingsProvider.theme == ThemeSettings.dark

--- a/lib/pages/import_export.dart
+++ b/lib/pages/import_export.dart
@@ -660,20 +660,33 @@ class _ImportExportPageState extends State<ImportExportPage> {
                           tr('importExportCardUpdateAssets'),
                           Icons.system_update_rounded,
                         ),
-                        FutureBuilder<Uri?>(
-                          future: settingsProvider.getApkSaveDir(),
+                        FutureBuilder<List<Uri?>>(
+                          future: Future.wait<Uri?>([
+                            settingsProvider.getApkSaveDir(
+                              requireAccess: false,
+                            ),
+                            settingsProvider.getApkSaveDir(),
+                          ]),
                           builder: (context, apkSaveSnapshot) {
+                            final Uri? savedApkSaveUri =
+                                apkSaveSnapshot.data?[0];
+                            final Uri? accessibleApkSaveUri =
+                                apkSaveSnapshot.data?[1];
+                            final bool apkSaveDirInaccessible =
+                                savedApkSaveUri != null &&
+                                accessibleApkSaveUri == null;
                             final String apkFolderTitle =
-                                apkSaveSnapshot.data == null
+                                savedApkSaveUri == null
                                 ? tr('pickApkSaveDir')
-                                : folderDisplayPathFromTreeUri(
-                                    apkSaveSnapshot.data!,
-                                  );
+                                : folderDisplayPathFromTreeUri(savedApkSaveUri);
+                            final Color apkFolderDescriptionColor =
+                                apkSaveDirInaccessible
+                                ? impScheme.error
+                                : impScheme.onSurfaceVariant;
                             return importPageCard([
                               resettableImportPageRow(
                                 onReset:
-                                    importInProgress ||
-                                        apkSaveSnapshot.data == null
+                                    importInProgress || savedApkSaveUri == null
                                     ? null
                                     : () async {
                                         await settingsProvider.pickApkSaveDir(
@@ -697,21 +710,31 @@ class _ImportExportPageState extends State<ImportExportPage> {
                                           children: [
                                             Text(
                                               apkFolderTitle,
-                                              style: Theme.of(
-                                                context,
-                                              ).textTheme.titleSmall,
+                                              style: Theme.of(context)
+                                                  .textTheme
+                                                  .titleSmall
+                                                  ?.copyWith(
+                                                    color:
+                                                        apkSaveDirInaccessible
+                                                        ? impScheme.error
+                                                        : null,
+                                                  ),
                                               maxLines: 3,
                                               overflow: TextOverflow.ellipsis,
                                             ),
                                             const SizedBox(height: 4),
                                             Text(
-                                              tr('apkSaveFolderDescription'),
+                                              tr(
+                                                apkSaveDirInaccessible
+                                                    ? 'storagePermissionDenied'
+                                                    : 'apkSaveFolderDescription',
+                                              ),
                                               style: Theme.of(context)
                                                   .textTheme
                                                   .bodySmall
                                                   ?.copyWith(
-                                                    color: impScheme
-                                                        .onSurfaceVariant,
+                                                    color:
+                                                        apkFolderDescriptionColor,
                                                   ),
                                             ),
                                           ],
@@ -754,14 +777,26 @@ class _ImportExportPageState extends State<ImportExportPage> {
                         tr('importExportCardObtainxBackup'),
                         Icons.save_as_rounded,
                       ),
-                      FutureBuilder<Uri?>(
-                        future: settingsProvider.getExportDir(),
+                      FutureBuilder<List<Uri?>>(
+                        future: Future.wait<Uri?>([
+                          settingsProvider.getExportDir(requireAccess: false),
+                          settingsProvider.getExportDir(),
+                        ]),
                         builder: (context, exportSnapshot) {
+                          final Uri? savedExportUri = exportSnapshot.data?[0];
+                          final Uri? accessibleExportUri =
+                              exportSnapshot.data?[1];
+                          final bool exportDirInaccessible =
+                              savedExportUri != null &&
+                              accessibleExportUri == null;
+                          final Color exportFolderDescriptionColor =
+                              exportDirInaccessible
+                              ? impScheme.error
+                              : impScheme.onSurfaceVariant;
                           return importPageCard([
                             resettableImportPageRow(
                               onReset:
-                                  importInProgress ||
-                                      exportSnapshot.data == null
+                                  importInProgress || savedExportUri == null
                                   ? null
                                   : () async {
                                       await settingsProvider.pickExportDir(
@@ -783,26 +818,35 @@ class _ImportExportPageState extends State<ImportExportPage> {
                                         mainAxisSize: MainAxisSize.min,
                                         children: [
                                           Text(
-                                            exportSnapshot.data == null
+                                            savedExportUri == null
                                                 ? tr('pickConfigExportFolder')
                                                 : folderDisplayPathFromTreeUri(
-                                                    exportSnapshot.data!,
+                                                    savedExportUri,
                                                   ),
-                                            style: Theme.of(
-                                              context,
-                                            ).textTheme.titleSmall,
+                                            style: Theme.of(context)
+                                                .textTheme
+                                                .titleSmall
+                                                ?.copyWith(
+                                                  color: exportDirInaccessible
+                                                      ? impScheme.error
+                                                      : null,
+                                                ),
                                             maxLines: 3,
                                             overflow: TextOverflow.ellipsis,
                                           ),
                                           const SizedBox(height: 4),
                                           Text(
-                                            tr('configExportFolderDescription'),
+                                            tr(
+                                              exportDirInaccessible
+                                                  ? 'storagePermissionDenied'
+                                                  : 'configExportFolderDescription',
+                                            ),
                                             style: Theme.of(context)
                                                 .textTheme
                                                 .bodySmall
                                                 ?.copyWith(
-                                                  color: impScheme
-                                                      .onSurfaceVariant,
+                                                  color:
+                                                      exportFolderDescriptionColor,
                                                 ),
                                           ),
                                         ],

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -465,42 +465,128 @@ class _SettingsPageState extends State<SettingsPage> {
     Widget sectionHeader(String title, IconData icon, String key) {
       final bool expanded =
           settingsProvider.prefs?.getBool('settingsSection_$key') ?? true;
-      return InkWell(
-        onTap: () =>
-            settingsProvider.setSettingBool('settingsSection_$key', !expanded),
-        borderRadius: BorderRadius.circular(8),
-        splashFactory: NoSplash.splashFactory,
-        splashColor: Colors.transparent,
-        highlightColor: Colors.transparent,
-        hoverColor: Colors.transparent,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(4, 20, 4, 8),
-          child: Row(
-            children: [
-              Icon(icon, color: cs.primary, size: 16),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  title,
-                  style: TextStyle(
-                    fontWeight: FontWeight.w600,
-                    color: cs.primary,
-                    fontSize: 13,
-                    decoration: TextDecoration.none,
+      const Duration headerTransitionDuration = Duration(milliseconds: 300);
+      final Color collapsedHeaderColor = Color.lerp(
+        cs.secondaryContainer,
+        cs.primaryContainer,
+        0.30,
+      )!;
+      final Color collapsedHeaderContentColor = cs.onSecondaryContainer;
+
+      return Padding(
+        padding: EdgeInsets.fromLTRB(0, expanded ? 20 : 16, 0, 8),
+        child: AnimatedSwitcher(
+          duration: headerTransitionDuration,
+          switchInCurve: Curves.easeOutCubic,
+          switchOutCurve: Curves.easeInCubic,
+          transitionBuilder: (Widget child, Animation<double> animation) {
+            return FadeTransition(
+              opacity: animation,
+              child: SizeTransition(
+                sizeFactor: animation,
+                axisAlignment: -1,
+                child: child,
+              ),
+            );
+          },
+          child: expanded
+              ? InkWell(
+                  key: ValueKey<String>('settingsHeaderText_$key'),
+                  onTap: () => settingsProvider.setSettingBool(
+                    'settingsSection_$key',
+                    false,
+                  ),
+                  borderRadius: BorderRadius.circular(8),
+                  splashFactory: NoSplash.splashFactory,
+                  splashColor: Colors.transparent,
+                  highlightColor: Colors.transparent,
+                  hoverColor: Colors.transparent,
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(4, 0, 4, 0),
+                    child: Row(
+                      children: [
+                        Icon(icon, color: cs.primary, size: 16),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            title,
+                            style: TextStyle(
+                              fontWeight: FontWeight.w600,
+                              color: cs.primary,
+                              fontSize: 13,
+                              decoration: TextDecoration.none,
+                            ),
+                          ),
+                        ),
+                        Icon(
+                          Icons.keyboard_arrow_down_rounded,
+                          color: cs.primary,
+                          size: 18,
+                        ),
+                      ],
+                    ),
+                  ),
+                )
+              : DecoratedBox(
+                  key: ValueKey<String>('settingsHeaderPill_$key'),
+                  decoration: ShapeDecoration(
+                    color: collapsedHeaderColor,
+                    shape: StadiumBorder(
+                      side: m3ePureBlackOutlineSide(cs, alpha: 0.16),
+                    ),
+                  ),
+                  child: Material(
+                    type: MaterialType.transparency,
+                    child: InkWell(
+                      onTap: () => settingsProvider.setSettingBool(
+                        'settingsSection_$key',
+                        true,
+                      ),
+                      customBorder: const StadiumBorder(),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 8,
+                        ),
+                        child: Row(
+                          children: [
+                            Container(
+                              width: 30,
+                              height: 30,
+                              decoration: BoxDecoration(
+                                color: cs.primary.withValues(alpha: 0.16),
+                                shape: BoxShape.circle,
+                              ),
+                              child: Icon(
+                                icon,
+                                color: collapsedHeaderContentColor,
+                                size: 17,
+                              ),
+                            ),
+                            const SizedBox(width: 10),
+                            Expanded(
+                              child: Text(
+                                title,
+                                style: TextStyle(
+                                  fontWeight: FontWeight.w700,
+                                  color: collapsedHeaderContentColor,
+                                  fontSize: 13,
+                                  letterSpacing: 0.1,
+                                  decoration: TextDecoration.none,
+                                ),
+                              ),
+                            ),
+                            Icon(
+                              Icons.keyboard_arrow_right_rounded,
+                              color: collapsedHeaderContentColor,
+                              size: 22,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
                   ),
                 ),
-              ),
-              AnimatedRotation(
-                turns: expanded ? 0 : -0.25,
-                duration: const Duration(milliseconds: 200),
-                child: Icon(
-                  Icons.keyboard_arrow_down_rounded,
-                  color: cs.primary,
-                  size: 18,
-                ),
-              ),
-            ],
-          ),
         ),
       );
     }
@@ -519,11 +605,16 @@ class _SettingsPageState extends State<SettingsPage> {
       return ClipRect(
         clipper: _SettingsSectionShadowClipper(expanded: expanded),
         child: AnimatedAlign(
-          duration: const Duration(milliseconds: 250),
-          curve: Curves.easeInOut,
+          duration: const Duration(milliseconds: 360),
+          curve: Curves.easeInOutCubicEmphasized,
           alignment: Alignment.topCenter,
           heightFactor: expanded ? 1.0 : 0.0,
-          child: settingsCard(children),
+          child: AnimatedOpacity(
+            duration: Duration(milliseconds: expanded ? 260 : 140),
+            curve: expanded ? Curves.easeOutCubic : Curves.easeInCubic,
+            opacity: expanded ? 1.0 : 0.0,
+            child: settingsCard(children),
+          ),
         ),
       );
     }

--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -1095,13 +1095,15 @@ class RemoveAppsWithModalResult {
 }
 
 class AppsProvider with ChangeNotifier {
-  // Lowered from 4 to 2 alongside moving HTML parsing off the UI isolate.
-  // Even with parses now running on background isolates via
-  // [parseHtmlOffIsolate], two concurrent network+parse pipelines is enough
-  // to saturate phones' typical wifi+cpu envelope; cranking it higher
-  // mostly added isolate-spawn churn and rate-limiting pressure on
-  // upstream sources without speeding up the wall-clock refresh.
-  static const int _maxParallelUpdateChecks = 2;
+  // Start fast on capable devices, but keep a bounded worker pool so a large
+  // app list does not fan out unbounded HTTP + parse work like upstream
+  // Obtainium. [_maxParallelUpdateChecksForDevice] lowers this on low-end
+  // devices using Android's low-RAM flag and total physical RAM.
+  static const int _defaultParallelUpdateChecks = 8;
+  static const int _modestDeviceParallelUpdateChecks = 4;
+  static const int _lowEndDeviceParallelUpdateChecks = 2;
+  static const int _lowEndRamThresholdMb = 3072;
+  static const int _modestRamThresholdMb = 6144;
 
   // In memory App state (should always be kept in sync with local storage versions)
   Map<String, AppInMemory> apps = {};
@@ -1180,6 +1182,25 @@ class AppsProvider with ChangeNotifier {
 
   void finishDetailPageAutoCheck(String appId) {
     _detailPageAutoChecksInFlight.remove(appId);
+  }
+
+  Future<int> _maxParallelUpdateChecksForDevice() async {
+    try {
+      final androidInfo = await DeviceInfoPlugin().androidInfo;
+      if (androidInfo.isLowRamDevice ||
+          (androidInfo.physicalRamSize > 0 &&
+              androidInfo.physicalRamSize <= _lowEndRamThresholdMb)) {
+        return _lowEndDeviceParallelUpdateChecks;
+      }
+      if (androidInfo.physicalRamSize > 0 &&
+          androidInfo.physicalRamSize <= _modestRamThresholdMb) {
+        return _modestDeviceParallelUpdateChecks;
+      }
+    } catch (_) {
+      // If device info is unavailable, prefer speed and keep the bounded
+      // default rather than silently falling back to the slowest path.
+    }
+    return _defaultParallelUpdateChecks;
   }
 
   void cancelDownload(String appId) {
@@ -3579,9 +3600,11 @@ class AppsProvider with ChangeNotifier {
         var appSaveCompleted = false;
         var lastProgressNotificationAt = DateTime.fromMicrosecondsSinceEpoch(0);
         const progressNotificationInterval = Duration(milliseconds: 250);
-        final workerCount = appIds.length < _maxParallelUpdateChecks
+        final maxParallelUpdateChecks =
+            await _maxParallelUpdateChecksForDevice();
+        final workerCount = appIds.length < maxParallelUpdateChecks
             ? appIds.length
-            : _maxParallelUpdateChecks;
+            : maxParallelUpdateChecks;
 
         Future<void> runUpdateCheckWorker() async {
           while (true) {

--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -1733,7 +1733,9 @@ class AppsProvider with ChangeNotifier {
     try {
       final App? appForSave = apps[dir.appId]?.app;
       final bool saveApkCopies = settingsProvider.saveDownloadedApkCopies;
-      final Uri? resolvedApkSaveUri = await settingsProvider.getApkSaveDir();
+      final Uri? resolvedApkSaveUri = await settingsProvider.getApkSaveDir(
+        warnIfInaccessible: saveApkCopies,
+      );
       var bundleCopiedOk = false;
       if (Platform.isAndroid &&
           saveApkCopies &&
@@ -1809,7 +1811,7 @@ class AppsProvider with ChangeNotifier {
         settingsProvider.saveDownloadedApkCopies &&
         !skipApkSaveFolderPersistForPrimaryApk;
     final Uri? apkSaveTreeUri = saveApkCopiesRequested
-        ? await settingsProvider.getApkSaveDir()
+        ? await settingsProvider.getApkSaveDir(warnIfInaccessible: true)
         : null;
     var installReportedOk = false;
     try {
@@ -3777,7 +3779,9 @@ class AppsProvider with ChangeNotifier {
     SettingsProvider? sp,
   }) async {
     SettingsProvider settingsProvider = sp ?? this.settingsProvider;
-    var exportDir = await settingsProvider.getExportDir();
+    var exportDir = await settingsProvider.getExportDir(
+      warnIfInaccessible: true,
+    );
     if (isAuto) {
       if (settingsProvider.autoExportOnChanges != true) {
         return null;
@@ -3797,7 +3801,9 @@ class AppsProvider with ChangeNotifier {
     }
     if (exportDir == null || pickOnly) {
       await settingsProvider.pickExportDir();
-      exportDir = await settingsProvider.getExportDir();
+      exportDir = await settingsProvider.getExportDir(
+        warnIfInaccessible: true,
+      );
     }
     if (exportDir == null) {
       return null;

--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -30,6 +30,7 @@ import 'package:obtainium/components/generated_form.dart';
 import 'package:obtainium/components/generated_form_modal.dart';
 import 'package:obtainium/custom_errors.dart';
 import 'package:obtainium/main.dart';
+import 'package:obtainium/providers/native_provider.dart';
 import 'package:obtainium/providers/logs_provider.dart';
 import 'package:obtainium/providers/notifications_provider.dart';
 import 'package:obtainium/providers/settings_provider.dart';
@@ -770,6 +771,42 @@ String storeFacingDownloadDisplayNameForApp(App app) {
 }
 
 Future<File> downloadFile(
+  String url,
+  String fileName,
+  bool fileNameHasExt,
+  Function? onProgress,
+  String destDir, {
+  void Function(int?)? onContentLength,
+  bool useExisting = true,
+  Map<String, String>? headers,
+  bool allowInsecure = false,
+  LogsProvider? logs,
+  DownloadCancelToken? cancelToken,
+}) async {
+  final bool releaseDownloadKeepAwake =
+      await NativeFeatures.acquireDownloadKeepAwake();
+  try {
+    return await _downloadFile(
+      url,
+      fileName,
+      fileNameHasExt,
+      onProgress,
+      destDir,
+      onContentLength: onContentLength,
+      useExisting: useExisting,
+      headers: headers,
+      allowInsecure: allowInsecure,
+      logs: logs,
+      cancelToken: cancelToken,
+    );
+  } finally {
+    if (releaseDownloadKeepAwake) {
+      await NativeFeatures.releaseDownloadKeepAwake();
+    }
+  }
+}
+
+Future<File> _downloadFile(
   String url,
   String fileName,
   bool fileNameHasExt,

--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -3545,6 +3545,13 @@ class AppsProvider with ChangeNotifier {
         late List<String> appIds;
         if (specificIds != null) {
           appIds = specificIds.where((id) => apps.containsKey(id)).toList();
+          if (settingsProvider.onlyCheckInstalledOrTrackOnlyApps) {
+            appIds = appIds.where((id) {
+              final AppInMemory appInMemory = apps[id]!;
+              return appInMemory.app.installedVersion != null ||
+                  appInMemory.app.additionalSettings['trackOnly'] == true;
+            }).toList();
+          }
           if (ignoreAppsCheckedAfter != null) {
             final DateTime cutoff = ignoreAppsCheckedAfter;
             appIds = appIds.where((id) {

--- a/lib/providers/native_provider.dart
+++ b/lib/providers/native_provider.dart
@@ -7,6 +7,9 @@ class NativeFeatures {
   static const MethodChannel _powerChannel = MethodChannel(
     'dev.imranr.obtainium/power',
   );
+  static const MethodChannel _storageChannel = MethodChannel(
+    'dev.imranr.obtainium/storage',
+  );
   static bool _systemFontLoaded = false;
 
   static Future<ByteData> _readFileBytes(String path) async {
@@ -45,6 +48,23 @@ class NativeFeatures {
       // Best-effort cleanup; Android also releases locks if the process dies.
     } on MissingPluginException {
       // Non-Android builds do not provide this channel.
+    }
+  }
+
+  static Future<Uri?> openPersistedDocumentTree({Uri? initialUri}) async {
+    try {
+      final uriString = await _storageChannel.invokeMethod<String>(
+        'openPersistedDocumentTree',
+        <String, String?>{'initialUri': initialUri?.toString()},
+      );
+      if (uriString == null || uriString.isEmpty) {
+        return null;
+      }
+      return Uri.parse(uriString);
+    } on PlatformException {
+      return null;
+    } on MissingPluginException {
+      return null;
     }
   }
 }

--- a/lib/providers/native_provider.dart
+++ b/lib/providers/native_provider.dart
@@ -14,12 +14,12 @@ class NativeFeatures {
     return ByteData.view(bytes.buffer);
   }
 
-  static Future loadSystemFont() async {
+  static Future<void> loadSystemFont() async {
     if (_systemFontLoaded) return;
     var fontLoader = FontLoader('SystemFont');
     var fontFilePath = await AndroidSystemFont().getFilePath();
     fontLoader.addFont(_readFileBytes(fontFilePath!));
-    fontLoader.load();
+    await fontLoader.load();
     _systemFontLoaded = true;
   }
 

--- a/lib/providers/native_provider.dart
+++ b/lib/providers/native_provider.dart
@@ -67,4 +67,18 @@ class NativeFeatures {
       return null;
     }
   }
+
+  static Future<bool> hasPersistedDocumentTreePermission(Uri uri) async {
+    try {
+      return await _storageChannel.invokeMethod<bool>(
+            'hasPersistedDocumentTreePermission',
+            <String, String>{'uri': uri.toString()},
+          ) ??
+          false;
+    } on PlatformException {
+      return false;
+    } on MissingPluginException {
+      return false;
+    }
+  }
 }

--- a/lib/providers/native_provider.dart
+++ b/lib/providers/native_provider.dart
@@ -4,6 +4,9 @@ import 'package:android_system_font/android_system_font.dart';
 import 'package:flutter/services.dart';
 
 class NativeFeatures {
+  static const MethodChannel _powerChannel = MethodChannel(
+    'dev.imranr.obtainium/power',
+  );
   static bool _systemFontLoaded = false;
 
   static Future<ByteData> _readFileBytes(String path) async {
@@ -18,5 +21,30 @@ class NativeFeatures {
     fontLoader.addFont(_readFileBytes(fontFilePath!));
     fontLoader.load();
     _systemFontLoaded = true;
+  }
+
+  static Future<bool> acquireDownloadKeepAwake() async {
+    try {
+      return await _powerChannel.invokeMethod<bool>(
+            'acquireDownloadKeepAwake',
+          ) ??
+          false;
+    } on PlatformException {
+      // Downloads should still proceed if the platform cannot hold a lock.
+      return false;
+    } on MissingPluginException {
+      // Non-Android builds do not provide this channel.
+      return false;
+    }
+  }
+
+  static Future<void> releaseDownloadKeepAwake() async {
+    try {
+      await _powerChannel.invokeMethod('releaseDownloadKeepAwake');
+    } on PlatformException {
+      // Best-effort cleanup; Android also releases locks if the process dies.
+    } on MissingPluginException {
+      // Non-Android builds do not provide this channel.
+    }
   }
 }

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -9,6 +9,7 @@ import 'package:obtainium/app_sources/github.dart';
 import 'package:obtainium/main.dart';
 import 'package:obtainium/providers/apps_provider.dart';
 import 'package:obtainium/folders/app_folder.dart';
+import 'package:obtainium/providers/native_provider.dart';
 import 'package:obtainium/providers/source_provider.dart';
 import 'package:obtainium/theme/app_theme_accent.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -1024,16 +1025,14 @@ class SettingsProvider with ChangeNotifier {
       return null;
     }
     final Uri uri = Uri.parse(uriString);
-    Future<bool> canAccessExportTree(Uri treeUri) async {
-      final bool readable = await saf.canRead(treeUri) ?? false;
-      final bool writable = await saf.canWrite(treeUri) ?? false;
-      return readable && writable;
+    Future<bool> canWriteExportTree(Uri treeUri) async {
+      return await saf.canWrite(treeUri) ?? false;
     }
 
-    if (!await canAccessExportTree(uri)) {
+    if (!await canWriteExportTree(uri)) {
       // Transient SAF failures should not wipe a still-valid grant.
       await Future<void>.delayed(const Duration(milliseconds: 200));
-      if (!await canAccessExportTree(uri)) {
+      if (!await canWriteExportTree(uri)) {
         prefs?.remove('exportDir');
         notifyListeners();
         return null;
@@ -1059,7 +1058,11 @@ class SettingsProvider with ChangeNotifier {
     }
 
     final String? previousExportDirString = prefs?.getString('exportDir');
-    final Uri? newUri = await saf.openDocumentTree();
+    final Uri? newUri = await NativeFeatures.openPersistedDocumentTree(
+      initialUri: previousExportDirString == null
+          ? null
+          : Uri.parse(previousExportDirString),
+    );
 
     if (newUri == null) {
       return;
@@ -1088,15 +1091,13 @@ class SettingsProvider with ChangeNotifier {
       return null;
     }
     final Uri uri = Uri.parse(uriString);
-    Future<bool> canAccessApkSaveTree(Uri treeUri) async {
-      final bool readable = await saf.canRead(treeUri) ?? false;
-      final bool writable = await saf.canWrite(treeUri) ?? false;
-      return readable && writable;
+    Future<bool> canWriteApkSaveTree(Uri treeUri) async {
+      return await saf.canWrite(treeUri) ?? false;
     }
 
-    if (!await canAccessApkSaveTree(uri)) {
+    if (!await canWriteApkSaveTree(uri)) {
       await Future<void>.delayed(const Duration(milliseconds: 200));
-      if (!await canAccessApkSaveTree(uri)) {
+      if (!await canWriteApkSaveTree(uri)) {
         prefs?.remove('apkSaveDir');
         notifyListeners();
         return null;
@@ -1121,7 +1122,11 @@ class SettingsProvider with ChangeNotifier {
     }
 
     final String? previousApkSaveDirString = prefs?.getString('apkSaveDir');
-    final Uri? newUri = await saf.openDocumentTree();
+    final Uri? newUri = await NativeFeatures.openPersistedDocumentTree(
+      initialUri: previousApkSaveDirString == null
+          ? null
+          : Uri.parse(previousApkSaveDirString),
+    );
 
     if (newUri == null) {
       return;

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -58,6 +58,10 @@ class SettingsProvider with ChangeNotifier {
   bool justStarted = true;
   bool isTV = false;
 
+  static const Duration _storageAccessWarningCooldown = Duration(minutes: 5);
+  DateTime? _lastExportDirAccessWarningAt;
+  DateTime? _lastApkSaveDirAccessWarningAt;
+
   /// Mirrors last [setCategories] write; [getString] can lag [setString] briefly.
   Map<String, int>? _categoriesMemory;
 
@@ -1019,22 +1023,26 @@ class SettingsProvider with ChangeNotifier {
     notifyListeners();
   }
 
-  Future<Uri?> getExportDir() async {
+  Future<Uri?> getExportDir({
+    bool requireAccess = true,
+    bool warnIfInaccessible = false,
+  }) async {
     final String? uriString = prefs?.getString('exportDir');
     if (uriString == null) {
       return null;
     }
     final Uri uri = Uri.parse(uriString);
-    Future<bool> canWriteExportTree(Uri treeUri) async {
-      return await saf.canWrite(treeUri) ?? false;
+    if (!requireAccess) {
+      return uri;
     }
 
-    if (!await canWriteExportTree(uri)) {
-      // Transient SAF failures should not wipe a still-valid grant.
+    if (!await _canReadAndWriteSafTree(uri)) {
+      // Retry once so transient SAF failures do not hide a still-valid grant.
       await Future<void>.delayed(const Duration(milliseconds: 200));
-      if (!await canWriteExportTree(uri)) {
-        prefs?.remove('exportDir');
-        notifyListeners();
+      if (!await _canReadAndWriteSafTree(uri)) {
+        if (warnIfInaccessible) {
+          _showStorageAccessWarning(isExportDir: true);
+        }
         return null;
       }
     }
@@ -1085,21 +1093,25 @@ class SettingsProvider with ChangeNotifier {
     }
   }
 
-  Future<Uri?> getApkSaveDir() async {
+  Future<Uri?> getApkSaveDir({
+    bool requireAccess = true,
+    bool warnIfInaccessible = false,
+  }) async {
     final String? uriString = prefs?.getString('apkSaveDir');
     if (uriString == null) {
       return null;
     }
     final Uri uri = Uri.parse(uriString);
-    Future<bool> canWriteApkSaveTree(Uri treeUri) async {
-      return await saf.canWrite(treeUri) ?? false;
+    if (!requireAccess) {
+      return uri;
     }
 
-    if (!await canWriteApkSaveTree(uri)) {
+    if (!await _canReadAndWriteSafTree(uri)) {
       await Future<void>.delayed(const Duration(milliseconds: 200));
-      if (!await canWriteApkSaveTree(uri)) {
-        prefs?.remove('apkSaveDir');
-        notifyListeners();
+      if (!await _canReadAndWriteSafTree(uri)) {
+        if (warnIfInaccessible) {
+          _showStorageAccessWarning(isExportDir: false);
+        }
         return null;
       }
     }
@@ -1148,6 +1160,40 @@ class SettingsProvider with ChangeNotifier {
         );
       } catch (_) {}
     }
+  }
+
+  Future<bool> _canReadAndWriteSafTree(Uri treeUri) async {
+    if (await NativeFeatures.hasPersistedDocumentTreePermission(treeUri)) {
+      return true;
+    }
+
+    final bool canReadTree = await saf.canRead(treeUri) ?? false;
+    if (!canReadTree) {
+      return false;
+    }
+
+    final bool canWriteTree = await saf.canWrite(treeUri) ?? false;
+    return canWriteTree;
+  }
+
+  void _showStorageAccessWarning({required bool isExportDir}) {
+    final DateTime now = DateTime.now();
+    final DateTime? lastWarningAt = isExportDir
+        ? _lastExportDirAccessWarningAt
+        : _lastApkSaveDirAccessWarningAt;
+
+    if (lastWarningAt != null &&
+        now.difference(lastWarningAt) < _storageAccessWarningCooldown) {
+      return;
+    }
+
+    if (isExportDir) {
+      _lastExportDirAccessWarningAt = now;
+    } else {
+      _lastApkSaveDirAccessWarningAt = now;
+    }
+
+    Fluttertoast.showToast(msg: tr('storagePermissionDenied'));
   }
 
   /// When true (and an APK save folder is set), copies of downloaded APKs are

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -224,18 +224,18 @@ packages:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: b4fed1b2835da9d670d7bed7db79ae2a94b0f5ad6312268158a9b5479abbacdd
+      sha256: "6a642e1daa10190af89ba6cb6386c0df7d071a3592080bfe1e44faa63ae1df65"
       url: "https://pub.dev"
     source: hosted
-    version: "12.4.0"
+    version: "13.1.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
       name: device_info_plus_platform_interface
-      sha256: e1ea89119e34903dca74b883d0dd78eb762814f97fb6c76f35e9ff74d261a18f
+      sha256: "04b173a92e2d9161dfead145667037c8d834db725ce2e7b942bfe18fd2f45a46"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.3"
+    version: "8.1.0"
   dynamic_color:
     dependency: "direct main"
     description:
@@ -300,6 +300,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  ffi_leak_tracker:
+    dependency: transitive
+    description:
+      name: ffi_leak_tracker
+      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -312,10 +320,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: f13a03000d942e476bc1ff0a736d2e9de711d2f89a95cd4c1d88f861c3348387
+      sha256: "5813e430c9444b32c437628056297698e94bb7f804cf69fdf1a8912ff05dd918"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.2"
+    version: "12.0.0-beta.2"
   fixnum:
     dependency: transitive
     description:
@@ -500,10 +508,10 @@ packages:
     dependency: transitive
     description:
       name: gtk
-      sha256: e8ce9ca4b1df106e4d72dad201d345ea1a036cc12c360f1a7d5a758f78ffa42c
+      sha256: "4ff85b2a16724029dd9e5bbb5a94b6918f9973f74ba571c949d2002801879cf5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   hooks:
     dependency: transitive
     description:
@@ -868,18 +876,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "223873d106614442ea6f20db5a038685cc5b32a2fba81cdecaefbbae0523f7fa"
+      sha256: a857d8b1479250aff6b57a51b2c02d31ca05848d441817c43f1640c885c286c0
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.2"
+    version: "13.1.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
+      sha256: "7f7ae28cf400d13f811e297ff37742dba83b79e0a6f5dce14eec0248274e6ce9"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "7.1.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -987,10 +995,10 @@ packages:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "5e8377564d95166761a968ed96104e0569b6b6cc611faac92a36ab8a169112c3"
+      sha256: f8a08a13fb8f0f8c590df89d745000bed44a673ed94bac846739e1a016875c21
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.6+1"
+    version: "2.5.7"
   sqflite_darwin:
     dependency: transitive
     description:
@@ -1131,10 +1139,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -1211,18 +1219,18 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      sha256: a1fc9eb9248baa05dfc12ed5b66e377b3e23f095eec078e0371622b9033810d9
       url: "https://pub.dev"
     source: hosted
-    version: "5.15.0"
+    version: "6.2.0"
   win32_registry:
     dependency: transitive
     description:
       name: win32_registry
-      sha256: "6f1b564492d0147b330dd794fee8f512cec4977957f310f9951b5f9d83618dae"
+      sha256: "73b1d78920a9d6e03f8b4e43e612b87bf3152a0e5c5e5150267762b7c4116904"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.3"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.6.2+3620
+version: 2.6.3+3630
 
 environment:
   sdk: ^3.10.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,8 +53,8 @@ dependencies:
   url_launcher: ^6.3.2
   permission_handler: ^12.0.1
   fluttertoast: ^9.0.0
-  device_info_plus: ^12.4.0
-  file_picker: ^11.0.2
+  device_info_plus: ^13.1.0
+  file_picker: ^12.0.0-beta.2
   animations: ^2.1.2
   android_package_installer: # TODO: See if PR will be accepted (dev may not be active), else remove this comment
     git:
@@ -64,7 +64,7 @@ dependencies:
     git:
       url: https://github.com/ImranR98/android_package_manager
       ref: master
-  share_plus: ^12.0.2
+  share_plus: ^13.1.0
   sqflite: ^2.4.2
   easy_localization: ^3.0.8
   android_intent_plus: ^6.0.0


### PR DESCRIPTION
## ✨ Improved Features

- Added native Android keep-awake support for downloads using CPU wake locks and high-performance Wi-Fi locks so downloads can continue when the screen sleeps.
- Added a native persisted folder picker for APK save and backup folders, including read/write SAF permission persistence and persisted grant validation.
- Added visible inaccessible-folder states on the Import/Export page so saved folders with broken permissions are shown as permission problems instead of looking unset.
- Increased update-check concurrency on capable devices from 2 workers to an adaptive limit of 8, while lowering to 4 or 2 on modest/low-RAM devices. i.e. Update checks will run faster on capable devices. 
- Updated settings section headers with collapsed tonal pill styling, right-facing collapsed chevrons, and smoother expand/collapse motion.

## 🐛 Bug Fixes

- Fixed the “Use system font” setting by awaiting font load before the app renders.
- Fixed “Only check installed and track-only apps for updates” not being applied to specific-ID update checks.

## 🧰 Others

- Updated dependencies: `device_info_plus`, `file_picker`, and `share_plus`, plus related transitive dependency updates.
- Added transitive `ffi_leak_tracker` through updated Windows support dependencies.