### PR TITLE
fix github req proxy and use downloadingX translation key for download progress label

### DIFF
--- a/lib/app_sources/github.dart
+++ b/lib/app_sources/github.dart
@@ -474,8 +474,7 @@ class GitHub extends AppSource {
     Map<String, dynamic> additionalSettings,
   ) async {
     if ((additionalSettings['GHReqPrefix'] as String? ?? '').isNotEmpty) {
-      var uri = Uri.parse(reqUrl);
-      return 'https://${additionalSettings['GHReqPrefix']}/${uri.toString().substring('https://'.length)}';
+      return 'https://${additionalSettings['GHReqPrefix']}/$reqUrl';
     }
     return reqUrl;
   }
@@ -1144,10 +1143,15 @@ class GitHub extends AppSource {
   String undoGHProxyMod(
     String reqUrl,
     Map<String, String> sourceConfigSettingValues,
-  ) => reqUrl.replaceFirst(
-    'https://${sourceConfigSettingValues['GHReqPrefix']}/',
-    '',
-  );
+  ) {
+    var prefix = sourceConfigSettingValues['GHReqPrefix'] ?? '';
+    if (prefix.isEmpty) return reqUrl;
+    var proxyPrefix = 'https://$prefix/';
+    if (reqUrl.startsWith(proxyPrefix)) {
+      return reqUrl.substring(proxyPrefix.length);
+    }
+    return reqUrl;
+  }
 
   @override
   Future<Map<String, List<String>>> search(

--- a/lib/app_sources/github.dart
+++ b/lib/app_sources/github.dart
@@ -454,9 +454,9 @@ class GitHub extends AppSource {
       settingsProvider,
     );
     String? creds = sourceConfig['github-creds'];
-    if ((sourceConfig['GHReqPrefix'] ?? '').isNotEmpty) {
-      creds = null;
-    }
+    // if ((sourceConfig['GHReqPrefix'] ?? '').isNotEmpty) {
+    //   creds = null;
+    // }
     return tokenFromCreds(creds);
   }
 

--- a/lib/app_sources/github.dart
+++ b/lib/app_sources/github.dart
@@ -454,7 +454,7 @@ class GitHub extends AppSource {
       settingsProvider,
     );
     String? creds = sourceConfig['github-creds'];
-    if ((additionalSettings['GHReqPrefix'] as String? ?? '').isNotEmpty) {
+    if ((sourceConfig['GHReqPrefix'] ?? '').isNotEmpty) {
       creds = null;
     }
     return tokenFromCreds(creds);
@@ -474,8 +474,14 @@ class GitHub extends AppSource {
     String standardUrl,
     Map<String, dynamic> additionalSettings,
   ) async {
-    if ((additionalSettings['GHReqPrefix'] as String? ?? '').isNotEmpty) {
-      return 'https://${additionalSettings['GHReqPrefix']}/$assetUrl';
+    SettingsProvider settingsProvider = SettingsProvider();
+    await settingsProvider.initializeSettings();
+    var sourceConfig = await getSourceConfigValues(
+      additionalSettings,
+      settingsProvider,
+    );
+    if ((sourceConfig['GHReqPrefix'] ?? '').isNotEmpty) {
+      return 'https://${sourceConfig['GHReqPrefix']}/$assetUrl';
     }
     return assetUrl;
   }
@@ -485,8 +491,14 @@ class GitHub extends AppSource {
     String reqUrl,
     Map<String, dynamic> additionalSettings,
   ) async {
-    if ((additionalSettings['GHReqPrefix'] as String? ?? '').isNotEmpty) {
-      return 'https://${additionalSettings['GHReqPrefix']}/$reqUrl';
+    SettingsProvider settingsProvider = SettingsProvider();
+    await settingsProvider.initializeSettings();
+    var sourceConfig = await getSourceConfigValues(
+      additionalSettings,
+      settingsProvider,
+    );
+    if ((sourceConfig['GHReqPrefix'] ?? '').isNotEmpty) {
+      return 'https://${sourceConfig['GHReqPrefix']}/$reqUrl';
     }
     return reqUrl;
   }

--- a/lib/app_sources/github.dart
+++ b/lib/app_sources/github.dart
@@ -744,7 +744,7 @@ class GitHub extends AppSource {
             var ext = e['name'].toString().toLowerCase().split('.').last;
             var url = !isInstallableExt(ext, includeZips: includeZips)
                 ? (e['browser_download_url'] ?? e['url'])
-                : (e['url'] ?? e['browser_download_url']);
+                : (e['browser_download_url'] ?? e['url']);
             url = undoGHProxyMod(url, sourceConfigSettingValues);
             e['final_url'] = (e['name'] != null) && (url != null)
                 ? MapEntry(e['name'] as String, url as String)

--- a/lib/app_sources/github.dart
+++ b/lib/app_sources/github.dart
@@ -480,8 +480,9 @@ class GitHub extends AppSource {
       additionalSettings,
       settingsProvider,
     );
-    if ((sourceConfig['GHReqPrefix'] ?? '').isNotEmpty) {
-      return 'https://${sourceConfig['GHReqPrefix']}/$assetUrl';
+    var prefix = sourceConfig['GHReqPrefix'] ?? '';
+    if (prefix.isNotEmpty && !assetUrl.startsWith('https://$prefix/')) {
+      return 'https://$prefix/$assetUrl';
     }
     return assetUrl;
   }

--- a/lib/app_sources/github.dart
+++ b/lib/app_sources/github.dart
@@ -436,9 +436,9 @@ class GitHub extends AppSource {
     if (token != null && token.isNotEmpty) {
       headers[HttpHeaders.authorizationHeader] = 'Token $token';
     }
-    if (forAPKDownload == true) {
-      headers[HttpHeaders.acceptHeader] = 'application/octet-stream';
-    }
+    // if (forAPKDownload == true) {
+    //   headers[HttpHeaders.acceptHeader] = 'application/octet-stream';
+    // }
     if (headers.isNotEmpty) {
       return headers;
     } else {
@@ -466,6 +466,18 @@ class GitHub extends AppSource {
       return '${tr('githubSourceNote')} ${hostChanged ? tr('addInfoBelow') : tr('addInfoInSettings')}';
     }
     return null;
+  }
+
+  @override
+  Future<String> assetUrlPrefetchModifier(
+    String assetUrl,
+    String standardUrl,
+    Map<String, dynamic> additionalSettings,
+  ) async {
+    if ((additionalSettings['GHReqPrefix'] as String? ?? '').isNotEmpty) {
+      return 'https://${additionalSettings['GHReqPrefix']}/$assetUrl';
+    }
+    return assetUrl;
   }
 
   @override

--- a/lib/favicon_cache.dart
+++ b/lib/favicon_cache.dart
@@ -18,7 +18,7 @@ class FaviconCache {
   static Future<File> _fileFor(String host) async {
     final base = await getApplicationCacheDirectory();
     final dir = Directory('${base.path}/favicons');
-    if (!dir.existsSync()) dir.createSync(recursive: true);
+    if (!await dir.exists()) await dir.create(recursive: true);
     return File('${dir.path}/${_fileName(host)}');
   }
 
@@ -28,8 +28,8 @@ class FaviconCache {
     if (_mem.containsKey(host)) return _mem[host];
 
     final file = await _fileFor(host);
-    if (file.existsSync()) {
-      final bytes = file.readAsBytesSync();
+    if (await file.exists()) {
+      final bytes = await file.readAsBytes();
       _mem[host] = bytes;
       return bytes;
     }

--- a/lib/pages/app.dart
+++ b/lib/pages/app.dart
@@ -3529,7 +3529,7 @@ class _AppPageState extends State<AppPage> {
             : '';
         final String label = isInstalling
             ? '${tr('installing')}…'
-            : 'Downloading ${dp.round()}%$bytesLabel';
+            : tr('downloadingX', args: ['${dp.round()}%$bytesLabel']);
         final Widget progressBar = ClipRRect(
           borderRadius: BorderRadius.circular(expressiveRadius),
           child: SizedBox(

--- a/lib/pages/apps.dart
+++ b/lib/pages/apps.dart
@@ -222,65 +222,49 @@ int _appsPageAppsRebuildToken(AppsProvider provider) {
 /// Progress bar shown during pull-to-refresh and initial app-load.
 ///
 /// Subscribes to [AppsProvider] via a narrow [context.select] that returns
-/// only `(loadingApps, checkedCount)`. As [AppsProvider.checkUpdates] saves
-/// each app and calls [AppsProvider.notifyListeners] (~ every 250 ms),
-/// `checkedCount` ticks up and only THIS widget rebuilds - the surrounding
-/// [AppsPage] (filter / sort / sliver list) does not.
+/// only `(loadingApps, progressCheckedCount)`. As [AppsProvider.checkUpdates]
+/// saves each app and calls [AppsProvider.notifyListeners] (~ every 250 ms),
+/// `progressCheckedCount` ticks up and only THIS widget rebuilds — the
+/// surrounding [AppsPage] (filter / sort / sliver list) does not.
 ///
 /// Counterpart to the deliberate exclusion of [App.lastUpdateCheck] from
 /// [_appsPageAppsRebuildToken]. That exclusion is what fixed the scroll
 /// stutter; this widget restores the live progress feedback that the
 /// exclusion would otherwise have stripped out.
+///
+/// Performance note: previously, the build callback iterated **every** app
+/// (O(n) with per-app `folderIdsForApp` List allocations) on every 250 ms
+/// progress tick. Now it reads two ints from the provider: O(1).
 class _RefreshProgressBar extends StatelessWidget {
   const _RefreshProgressBar({
     required this.refreshingSince,
     required this.progressDenominator,
-    required this.onDemandOnlyList,
-    required this.folderId,
   });
 
   final DateTime? refreshingSince;
   final int progressDenominator;
-  final bool onDemandOnlyList;
-  final String? folderId;
 
   @override
   Widget build(BuildContext context) {
+    // O(1): read two fields from the provider — no iteration, no allocation.
     final (bool loadingApps, int checkedCount) = context
-        .select<AppsProvider, (bool, int)>((p) {
-          if (p.loadingApps) {
-            return (true, 0);
-          }
-          final DateTime? since = refreshingSince;
-          if (since == null) {
-            return (false, 0);
-          }
-          int count = 0;
-          for (final a in p.apps.values) {
-            final last = a.app.lastUpdateCheck;
-            if (last == null || last.isBefore(since)) continue;
-            if (onDemandOnlyList &&
-                a.app.additionalSettings['onDemandOnly'] != true) {
-              continue;
-            }
-            final String? folder = folderId;
-            if (folder != null && !folderIdsForApp(a.app).contains(folder)) {
-              continue;
-            }
-            count++;
-          }
-          return (false, count);
-        });
+        .select<AppsProvider, (bool, int)>((p) => (p.loadingApps, p.progressCheckedCount));
     // M3 Expressive linear progress indicator. Wavy active track with a
     // stop-dot at the end (per the M3E spec). The widget draws two
     // separate lanes (active above, track below) with a fixed gap so the
     // active and inactive segments never overlap.
-    return LinearProgressIndicatorM3E(
-      value: loadingApps
-          ? null
-          : (progressDenominator > 0
-                ? checkedCount / progressDenominator
-                : 0.0),
+    //
+    // RepaintBoundary isolates this widget's animation repaints from the
+    // rest of the tree. Without it, the animated progress line forces a
+    // relayout/re-paint of its parent subtree every tick.
+    return RepaintBoundary(
+      child: LinearProgressIndicatorM3E(
+        value: loadingApps
+            ? null
+            : (progressDenominator > 0
+                  ? checkedCount / progressDenominator
+                  : 0.0),
+      ),
     );
   }
 }
@@ -3205,8 +3189,6 @@ class AppsPageState extends State<AppsPage> {
               child: _RefreshProgressBar(
                 refreshingSince: refreshingSince,
                 progressDenominator: progressDenominator,
-                onDemandOnlyList: widget.onDemandOnlyList,
-                folderId: progressFolderId,
               ),
             ),
           ),

--- a/lib/pages/apps.dart
+++ b/lib/pages/apps.dart
@@ -2064,8 +2064,14 @@ class AppsPageState extends State<AppsPage> {
   // row selection or the refresh-indicator doesn't need a new sort).
   int? _lastListBuildToken;
   List<AppInMemory> _listedAppsCache = const [];
-  List<String> _existingUpdatesCache = const [];
-  List<String> _newInstallsCache = const [];
+  // Set for O(1) lookup in pinUpdates pass and isInUpdatesGroup checks;
+  // previously a List<String> making every row's contains() O(n).
+  Set<String> _existingUpdatesCache = const {};
+  Set<String> _newInstallsCache = const {};
+  // Cached per-folder app / update counts, computed in a single O(n) pass.
+  Map<String, int> _folderAppCountsCache = const {};
+  Map<String, int> _folderUpdateCountsCache = const {};
+  int? _lastFolderCountsToken;
   List<String> _listedSourcesCache = const [];
   List<String?> _listedCategoriesCache = const [];
   List<AppTypeGroup> _listedAppTypesCache = const [];
@@ -2805,15 +2811,16 @@ class AppsPageState extends State<AppsPage> {
 
       // Cache existingUpdates together with the list: pinUpdates ordering
       // depends on it and it's a pure function of app state (in the token).
+      // Stored as Set for O(1) contains() — was List making every row O(n).
       _existingUpdatesCache = appsProvider
           .findExistingUpdates(
             installedOnly: true,
             includeVersionOrderUncertain: true,
           )
-          .toList();
+          .toSet();
       _newInstallsCache = appsProvider
           .findExistingUpdates(nonInstalledOnly: true)
-          .toList();
+          .toSet();
 
       if (_effectivePinUpdates(settingsProvider)) {
         final temp = <AppInMemory>[];
@@ -2859,30 +2866,33 @@ class AppsPageState extends State<AppsPage> {
         .length;
 
     // Folder counts: number of non-on-demand apps in each folder.
+    // Single O(n) pass over apps instead of O(n × folders); cached on
+    // listBuildToken so repeated build() calls skip the pass entirely.
+    if (listBuildToken != _lastFolderCountsToken) {
+      _lastFolderCountsToken = listBuildToken;
+      final appFolders = settingsProvider.appFolders;
+      final folderAppCounts = <String, int>{for (final f in appFolders) f.id: 0};
+      final folderUpdateCounts = <String, int>{for (final f in appFolders) f.id: 0};
+      for (final a in appsProvider.apps.values) {
+        if (a.app.additionalSettings['onDemandOnly'] == true) continue;
+        final fIds = folderIdsForApp(a.app);
+        final hasUpdate = appHasActionableUpdate(a.app) ||
+            versionOrderUncertainUpdate(a.app);
+        for (final fId in fIds) {
+          if (folderAppCounts.containsKey(fId)) {
+            folderAppCounts[fId] = folderAppCounts[fId]! + 1;
+            if (hasUpdate) {
+              folderUpdateCounts[fId] = folderUpdateCounts[fId]! + 1;
+            }
+          }
+        }
+      }
+      _folderAppCountsCache = folderAppCounts;
+      _folderUpdateCountsCache = folderUpdateCounts;
+    }
+    final Map<String, int> folderAppCounts = _folderAppCountsCache;
+    final Map<String, int> folderUpdateCounts = _folderUpdateCountsCache;
     final appFolders = settingsProvider.appFolders;
-    final Map<String, int> folderAppCounts = {
-      for (final f in appFolders)
-        f.id: appsProvider.apps.values
-            .where(
-              (a) =>
-                  a.app.additionalSettings['onDemandOnly'] != true &&
-                  folderIdsForApp(a.app).contains(f.id),
-            )
-            .length,
-    };
-    // Update counts per folder (mirrors the badge logic on the home tab icon).
-    final Map<String, int> folderUpdateCounts = {
-      for (final f in appFolders)
-        f.id: appsProvider.apps.values
-            .where(
-              (a) =>
-                  a.app.additionalSettings['onDemandOnly'] != true &&
-                  folderIdsForApp(a.app).contains(f.id) &&
-                  (appHasActionableUpdate(a.app) ||
-                      versionOrderUncertainUpdate(a.app)),
-            )
-            .length,
-    };
     final String? currentFolderName = widget.folderId != null
         ? appFolders
               .where((f) => f.id == widget.folderId)
@@ -2994,145 +3004,90 @@ class AppsPageState extends State<AppsPage> {
     if (listBuildToken != _lastGroupIndexCacheToken) {
       _lastGroupIndexCacheToken = listBuildToken;
 
-      // 1. Categories
+      // 1. Categories — single O(n) pass instead of O(categories × n)
       if (effectiveGroupBy == AppsListGroupBy.category) {
-        List<String?> getListedCategories(List<AppInMemory> appsSource) {
-          var temp = appsSource.map(
-            (e) => e.app.categories.isNotEmpty ? e.app.categories : [null],
-          );
-          return temp.isNotEmpty
-              ? {
-                  ...temp.reduce((v, e) => [...v, ...e]),
-                }.toList()
-              : [];
-        }
-
-        final cats = getListedCategories(appsListedForCategoryKeys);
-        cats.sort((a, b) {
-          return a != null && b != null
-              ? a.toLowerCase().compareTo(b.toLowerCase())
-              : a == null
-              ? 1
-              : -1;
-        });
-        _listedCategoriesCache = cats;
-
-        final nextCategoryMap = <String, List<int>>{};
+        // Collect all category keys and their app indices in one pass.
+        final categoryIndices = <String, List<int>>{};
         for (
-          int categoryIndex = 0;
-          categoryIndex < _listedCategoriesCache.length;
-          categoryIndex++
+          int listingIndex = 0;
+          listingIndex < listedApps.length;
+          listingIndex++
         ) {
-          final String? categoryNullable = _listedCategoriesCache[categoryIndex];
-          final String mapKey = categoryNullable ?? '__null__';
-          final indices = <int>[];
-          for (
-            int listingIndex = 0;
-            listingIndex < listedApps.length;
-            listingIndex++
-          ) {
-            final AppInMemory row = listedApps[listingIndex];
-            if (segregateNonInstalled && row.app.installedVersion == null) {
-              continue;
-            }
-            if (isInUpdatesGroup(row)) continue;
-            if (row.app.categories.contains(categoryNullable) ||
-                (row.app.categories.isEmpty && categoryNullable == null)) {
-              indices.add(listingIndex);
-            }
+          final AppInMemory row = listedApps[listingIndex];
+          if (segregateNonInstalled && row.app.installedVersion == null) {
+            continue;
           }
-          nextCategoryMap[mapKey] = indices;
+          if (isInUpdatesGroup(row)) continue;
+          final cats = row.app.categories.isEmpty
+              ? const <String?>[null]
+              : row.app.categories;
+          for (final cat in cats) {
+            final key = cat ?? '__null__';
+            categoryIndices.putIfAbsent(key, () => <int>[]).add(listingIndex);
+          }
         }
-        _categoryGroupListedIndices = nextCategoryMap;
+        final sortedKeys = categoryIndices.keys.toList(growable: false)
+          ..sort((a, b) {
+            // '__null__' goes last; others sort alphabetically (case-insensitive).
+            if (a == '__null__') return 1;
+            if (b == '__null__') return -1;
+            return a.toLowerCase().compareTo(b.toLowerCase());
+          });
+        _listedCategoriesCache = sortedKeys
+            .map((k) => k == '__null__' ? null : k)
+            .toList(growable: false);
+        _categoryGroupListedIndices = categoryIndices;
       } else {
         _listedCategoriesCache = const [];
         _categoryGroupListedIndices = const {};
       }
 
-      // 2. Sources
+      // 2. Sources — single O(n) pass, one getSource() call per app
       if (effectiveGroupBy == AppsListGroupBy.source) {
-        List<String> getListedSourceKeys(List<AppInMemory> appsSource) {
-          if (appsSource.isEmpty) return [];
-          final keys = appsSource
-              .map(
-                (e) => sourceProvider
-                    .getSource(e.app.url, overrideSource: e.app.overrideSource)
-                    .runtimeType
-                    .toString(),
-              )
-              .toSet()
-              .toList();
-          keys.sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
-          return keys;
-        }
-
-        _listedSourcesCache = getListedSourceKeys(appsListedForSourceKeys);
-
-        final nextSourceMap = <String, List<int>>{};
+        final sourceIndices = <String, List<int>>{};
         for (
-          int sourceIndex = 0;
-          sourceIndex < _listedSourcesCache.length;
-          sourceIndex++
+          int listingIndex = 0;
+          listingIndex < listedApps.length;
+          listingIndex++
         ) {
-          final String sourceKey = _listedSourcesCache[sourceIndex];
-          final indices = <int>[];
-          for (
-            int listingIndex = 0;
-            listingIndex < listedApps.length;
-            listingIndex++
-          ) {
-            final AppInMemory row = listedApps[listingIndex];
-            if (segregateNonInstalled && row.app.installedVersion == null) {
-              continue;
-            }
-            if (isInUpdatesGroup(row)) continue;
-            if (sourceProvider
-                    .getSource(
-                      row.app.url,
-                      overrideSource: row.app.overrideSource,
-                    )
-                    .runtimeType
-                    .toString() ==
-                sourceKey) {
-              indices.add(listingIndex);
-            }
+          final AppInMemory row = listedApps[listingIndex];
+          if (segregateNonInstalled && row.app.installedVersion == null) {
+            continue;
           }
-          nextSourceMap[sourceKey] = indices;
+          if (isInUpdatesGroup(row)) continue;
+          final key = sourceProvider
+              .getSource(row.app.url, overrideSource: row.app.overrideSource)
+              .runtimeType
+              .toString();
+          sourceIndices.putIfAbsent(key, () => <int>[]).add(listingIndex);
         }
-        _sourceGroupListedIndices = nextSourceMap;
+        final sortedKeys = sourceIndices.keys.toList(growable: false)
+          ..sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
+        _listedSourcesCache = sortedKeys;
+        _sourceGroupListedIndices = sourceIndices;
       } else {
         _listedSourcesCache = const [];
         _sourceGroupListedIndices = const {};
       }
 
-      // 3. App Types
+      // 3. App Types — single O(n) pass, one classifyAppType() per app
       if (effectiveGroupBy == AppsListGroupBy.appType) {
-        _listedAppTypesCache = AppTypeGroup.values
-            .where(
-              (t) => appsListedForAppTypeKeys.any((e) => classifyAppType(e) == t),
-            )
-            .toList();
-
-        final nextAppTypeMap = <AppTypeGroup, List<int>>{};
-        for (final type in _listedAppTypesCache) {
-          final indices = <int>[];
-          for (
-            int listingIndex = 0;
-            listingIndex < listedApps.length;
-            listingIndex++
-          ) {
-            final AppInMemory row = listedApps[listingIndex];
-            if (segregateNonInstalled && row.app.installedVersion == null) {
-              continue;
-            }
-            if (isInUpdatesGroup(row)) continue;
-            if (classifyAppType(row) == type) {
-              indices.add(listingIndex);
-            }
+        final appTypeIndices = <AppTypeGroup, List<int>>{};
+        for (
+          int listingIndex = 0;
+          listingIndex < listedApps.length;
+          listingIndex++
+        ) {
+          final AppInMemory row = listedApps[listingIndex];
+          if (segregateNonInstalled && row.app.installedVersion == null) {
+            continue;
           }
-          if (indices.isNotEmpty) nextAppTypeMap[type] = indices;
+          if (isInUpdatesGroup(row)) continue;
+          final type = classifyAppType(row);
+          appTypeIndices.putIfAbsent(type, () => <int>[]).add(listingIndex);
         }
-        _appTypeGroupListedIndices = nextAppTypeMap;
+        _listedAppTypesCache = appTypeIndices.keys.toList(growable: false);
+        _appTypeGroupListedIndices = appTypeIndices;
       } else {
         _listedAppTypesCache = const [];
         _appTypeGroupListedIndices = const {};

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -64,6 +64,18 @@ class SettingsPage extends StatefulWidget {
 class _SettingsPageState extends State<SettingsPage> {
   late final Future<AndroidDeviceInfo> _androidInfo =
       DeviceInfoPlugin().androidInfo;
+
+  // ── Scaffold-level subscriptions ────────────────────────────────────
+  // We deliberately avoid `context.watch<SettingsProvider>()`: that would
+  // rebuild this whole widget tree on every single setter change. Instead
+  // we subscribe only to the values needed for the Scaffold chrome, and
+  // let each section widget subscribe to its own narrow set.
+  static int _scaffoldSettingsHash(SettingsProvider sp) => Object.hash(
+        sp.prefs,
+        sp.useGradientBackground,
+        sp.progressiveBlurEnabled,
+      );
+
   static const List<String> _settingsSectionKeys = [
     'updates',
     'sourceSpecific',
@@ -73,7 +85,7 @@ class _SettingsPageState extends State<SettingsPage> {
     'categories',
   ];
 
-  List<int> updateIntervalNodes = [
+  static const List<int> updateIntervalNodes = [
     15,
     30,
     60,
@@ -87,433 +99,84 @@ class _SettingsPageState extends State<SettingsPage> {
     20160,
     43200,
   ];
-  int updateInterval = 0;
-  String updateIntervalLabel = tr('neverManualOnly');
-
-  void processIntervalSliderValue(double val) {
-    final int index = val.round().clamp(0, updateIntervalNodes.length);
-    if (index == 0) {
-      updateInterval = 0;
-      updateIntervalLabel = tr('neverManualOnly');
-      return;
-    }
-    final int minutes = updateIntervalNodes[index - 1];
-    updateInterval = minutes;
-    if (minutes < 60) {
-      updateIntervalLabel = plural('minute', minutes);
-    } else if (minutes < 24 * 60) {
-      updateIntervalLabel = plural('hour', minutes ~/ 60);
-    } else {
-      updateIntervalLabel = plural('day', minutes ~/ (24 * 60));
-    }
-  }
-
-  List<Widget> _updatesCardItemList(
-    BuildContext context,
-    ColorScheme cs,
-    SettingsProvider settingsProvider,
-    AsyncSnapshot<AndroidDeviceInfo> snapshot,
-    Widget updatesIntervalHead,
-  ) {
-    final List<Widget> rows = <Widget>[updatesIntervalHead];
-    final bool showBgControls =
-        (settingsProvider.updateInterval > 0) &&
-        (((snapshot.data?.version.sdkInt ?? 0) >= 30) ||
-            settingsProvider.useShizuku);
-    if (showBgControls) {
-      rows.add(
-        ListTile(
-          title: Text(tr('foregroundServiceForUpdateChecking')),
-          trailing: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              HelpHintIcon(
-                message: tr('foregroundServiceReliabilityNote'),
-                padding: EdgeInsets.zero,
-              ),
-              Switch(
-                value: settingsProvider.useFGService,
-                onChanged: (bool value) {
-                  settingsProvider.useFGService = value;
-                },
-              ),
-            ],
-          ),
-          onTap: () {
-            settingsProvider.useFGService = !settingsProvider.useFGService;
-          },
-        ),
-      );
-      rows.add(
-        ListTile(
-          title: Text(tr('enableBackgroundUpdates')),
-          trailing: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              HelpHintIcon(
-                message:
-                    '${tr('backgroundUpdateReqsExplanation')}\n\n${tr('backgroundUpdateLimitsExplanation')}',
-                padding: EdgeInsets.zero,
-              ),
-              Switch(
-                value: settingsProvider.enableBackgroundUpdates,
-                onChanged: (bool value) {
-                  settingsProvider.enableBackgroundUpdates = value;
-                },
-              ),
-            ],
-          ),
-          onTap: () {
-            settingsProvider.enableBackgroundUpdates =
-                !settingsProvider.enableBackgroundUpdates;
-          },
-        ),
-      );
-      if (settingsProvider.enableBackgroundUpdates) {
-        rows.add(
-          SwitchListTile(
-            title: Text(tr('bgUpdatesOnWiFiOnly')),
-            value: settingsProvider.bgUpdatesOnWiFiOnly,
-            onChanged: (bool value) {
-              settingsProvider.bgUpdatesOnWiFiOnly = value;
-            },
-          ),
-        );
-        rows.add(
-          SwitchListTile(
-            title: Text(tr('bgUpdatesWhileChargingOnly')),
-            value: settingsProvider.bgUpdatesWhileChargingOnly,
-            onChanged: (bool value) {
-              settingsProvider.bgUpdatesWhileChargingOnly = value;
-            },
-          ),
-        );
-      }
-    }
-    rows.addAll(<Widget>[
-      SwitchListTile(
-        title: Text(tr('checkOnStart')),
-        value: settingsProvider.checkOnStart,
-        onChanged: (bool value) {
-          settingsProvider.checkOnStart = value;
-        },
-      ),
-      SwitchListTile(
-        title: Text(tr('checkUpdateOnDetailPage')),
-        value: settingsProvider.checkUpdateOnDetailPage,
-        onChanged: (bool value) {
-          settingsProvider.checkUpdateOnDetailPage = value;
-        },
-      ),
-      SwitchListTile(
-        title: Text(tr('onlyCheckInstalledOrTrackOnlyApps')),
-        value: settingsProvider.onlyCheckInstalledOrTrackOnlyApps,
-        onChanged: (bool value) {
-          settingsProvider.onlyCheckInstalledOrTrackOnlyApps = value;
-        },
-      ),
-      SwitchListTile(
-        title: Text(tr('removeOnExternalUninstall')),
-        value: settingsProvider.removeOnExternalUninstall,
-        onChanged: (bool value) {
-          settingsProvider.removeOnExternalUninstall = value;
-        },
-      ),
-      SwitchListTile(
-        title: Text(tr('parallelDownloads')),
-        value: settingsProvider.parallelDownloads,
-        onChanged: (bool value) {
-          settingsProvider.parallelDownloads = value;
-        },
-      ),
-      ListTile(
-        title: Text(tr('beforeNewInstallsShareToAppVerifier')),
-        trailing: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            IconButton(
-              tooltip: tr('about'),
-              onPressed: () {
-                launchUrlString(
-                  'https://github.com/soupslurpr/AppVerifier',
-                  mode: LaunchMode.externalApplication,
-                );
-              },
-              style: IconButton.styleFrom(
-                foregroundColor: cs.onSurfaceVariant,
-                iconSize: 20,
-                padding: const EdgeInsets.all(4),
-                minimumSize: const Size(32, 32),
-                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                visualDensity: VisualDensity.compact,
-              ),
-              icon: const Icon(Icons.open_in_new_rounded),
-            ),
-            Switch(
-              value: settingsProvider.beforeNewInstallsShareToAppVerifier,
-              onChanged: (bool value) {
-                settingsProvider.beforeNewInstallsShareToAppVerifier = value;
-              },
-            ),
-          ],
-        ),
-      ),
-      Padding(
-        padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(tr('installerMode')),
-            const SizedBox(height: 4),
-            SizedBox(
-              width: double.infinity,
-              child: SegmentedButton<String>(
-                segments: [
-                  ButtonSegment<String>(
-                    value: 'stock',
-                    label: Text(tr('installerModeStock')),
-                  ),
-                  ButtonSegment<String>(
-                    value: 'shizuku',
-                    label: Text(tr('installerModeShizuku')),
-                  ),
-                  ButtonSegment<String>(
-                    value: 'legacy',
-                    label: Text(tr('installerModeThirdParty')),
-                  ),
-                ],
-                selected: {settingsProvider.installerMode},
-                onSelectionChanged: (Set<String> selected) {
-                  final String mode = selected.first;
-                  if (mode == 'shizuku') {
-                    ShizukuApkInstaller().checkPermission().then((
-                      String? resCode,
-                    ) {
-                      if (!context.mounted) return;
-                      if (resCode!.startsWith('granted')) {
-                        settingsProvider.installerMode = 'shizuku';
-                      } else {
-                        switch (resCode) {
-                          case 'services_not_found':
-                            showError(
-                              ObtainiumError(tr('shizukuBinderNotFound')),
-                              context,
-                            );
-                          case 'old_shizuku':
-                            showError(
-                              ObtainiumError(tr('shizukuOld')),
-                              context,
-                            );
-                          case 'old_android_with_adb':
-                            showError(
-                              ObtainiumError(tr('shizukuOldAndroidWithADB')),
-                              context,
-                            );
-                          case 'denied':
-                            showError(ObtainiumError(tr('cancelled')), context);
-                        }
-                      }
-                    });
-                  } else {
-                    settingsProvider.installerMode = mode;
-                  }
-                },
-              ),
-            ),
-            if (settingsProvider.installerMode == 'shizuku')
-              SwitchListTile(
-                contentPadding: EdgeInsets.zero,
-                title: Text(tr('shizukuPretendToBeGooglePlay')),
-                value: settingsProvider.shizukuPretendToBeGooglePlay,
-                onChanged: (bool value) {
-                  settingsProvider.shizukuPretendToBeGooglePlay = value;
-                },
-              ),
-            if (settingsProvider.installerMode == 'legacy')
-              Padding(
-                padding: const EdgeInsets.only(top: 8),
-                child: _ThirdPartyInstallerSelector(
-                  settingsProvider: settingsProvider,
-                ),
-              ),
-          ],
-        ),
-      ),
-    ]);
-    return rows;
-  }
 
   @override
   Widget build(BuildContext context) {
-    SettingsProvider settingsProvider = context.watch<SettingsProvider>();
+    // Narrow watch: only the values needed for the Scaffold chrome.
+    // Use context.select instead of context.watch to avoid rebuilding the
+    // whole page on every unrelated settings change.
+    final int scaffoldHash =
+        context.select<SettingsProvider, int>(_scaffoldSettingsHash);
+    final SettingsProvider sp = context.read<SettingsProvider>();
+    final ColorScheme cs = Theme.of(context).colorScheme;
     SourceProvider sourceProvider = SourceProvider();
-    if (settingsProvider.prefs == null) settingsProvider.initializeSettings();
-    processIntervalSliderValue(settingsProvider.updateIntervalSliderVal);
 
-    final Widget localeMenu = appDropdownField<String>(
-      key: ValueKey(
-        settingsProvider.forcedLocale?.toLanguageTag() ?? '_system',
-      ),
-      context: context,
-      value: settingsProvider.forcedLocale?.toLanguageTag() ?? '_system',
-      labelText: tr('language'),
-      menuWidth: appDropdownMenuWidth(
-        context,
-        [
-          tr('followSystem'),
-          ...supportedLocales.map(
-            (MapEntry<Locale, String> localeEntry) => localeEntry.value,
+    // One-time initialization guard.
+    if (sp.prefs == null) sp.initializeSettings();
+
+    // Collapse state: persisted in SharedPreferences but toggled via local
+    // setState so toggling a section header does NOT trigger a global
+    // notifyListeners / full-page rebuild.
+    final Map<String, bool> expandedState = <String, bool>{
+      for (final key in _settingsSectionKeys)
+        key: sp.prefs?.getBool('settingsSection_$key') ?? true,
+    };
+
+    void setSectionExpanded(String key, bool value) {
+      sp.prefs?.setBool('settingsSection_$key', value);
+      setState(() {});
+    }
+
+    void setAllSettingsSectionsExpanded(bool value) {
+      for (final sectionKey in _settingsSectionKeys) {
+        sp.prefs?.setBool('settingsSection_$sectionKey', value);
+      }
+      setState(() {});
+    }
+
+    final List<String> visibleSettingsSectionKeys = [
+      'updates',
+      if (sourceProvider.sources.any(
+        (source) => source.sourceConfigSettingFormItems.isNotEmpty,
+      ))
+        'sourceSpecific',
+      'themes',
+      'appearance',
+      'gestures',
+      'categories',
+    ];
+    final bool allSettingsSectionsExpanded =
+        visibleSettingsSectionKeys.every((k) => expandedState[k] ?? true);
+
+    Widget settingsCard(List<Widget> children) {
+      return m3eExpressiveSettingsCard(
+        context: context,
+        colorScheme: cs,
+        items: children,
+      );
+    }
+
+    Widget collapsibleCard(String key, Widget child) {
+      final bool expanded = expandedState[key] ?? true;
+      return ClipRect(
+        clipper: _SettingsSectionShadowClipper(expanded: expanded),
+        child: AnimatedAlign(
+          duration: const Duration(milliseconds: 360),
+          curve: Curves.easeInOutCubicEmphasized,
+          alignment: Alignment.topCenter,
+          heightFactor: expanded ? 1.0 : 0.0,
+          child: AnimatedOpacity(
+            duration: Duration(milliseconds: expanded ? 260 : 140),
+            curve: expanded ? Curves.easeOutCubic : Curves.easeInCubic,
+            opacity: expanded ? 1.0 : 0.0,
+            child: child,
           ),
-        ],
-        style: Theme.of(context).textTheme.bodyLarge,
-        horizontalPadding: 96,
-        minWidth: 150,
-      ),
-      items: [
-        DropdownMenuItem<String>(
-          value: '_system',
-          child: Text(tr('followSystem')),
         ),
-        ...supportedLocales.map(
-          (MapEntry<Locale, String> localeEntry) => DropdownMenuItem<String>(
-            value: localeEntry.key.toLanguageTag(),
-            child: Text(localeEntry.value),
-          ),
-        ),
-      ],
-      onChanged: (String? value) {
-        final Locale? selectedLocale = value == null || value == '_system'
-            ? null
-            : supportedLocales
-                  .firstWhere(
-                    (MapEntry<Locale, String> localeEntry) =>
-                        localeEntry.key.toLanguageTag() == value,
-                  )
-                  .key;
-        settingsProvider.forcedLocale = selectedLocale;
-        if (selectedLocale != null) {
-          context.setLocale(selectedLocale);
-        } else {
-          settingsProvider.resetLocaleSafe(context);
-        }
-      },
-    );
-
-    // M3 Expressive slider design - thick gapped track + vertical-bar thumb.
-    // Implemented via custom [SliderTrackShape] / [SliderComponentShape]
-    // painters at the bottom of this file. The slider_m3e package's
-    // "round" / "square" thumb variants don't match the M3E reference
-    // (which is a vertical-pill thumb), so we keep our spec-correct
-    // hand-built shapes.
-    var intervalSlider = SliderTheme(
-      data: SliderTheme.of(context).copyWith(
-        trackHeight: 16,
-        trackShape: const _GappedTrackShape(),
-        thumbShape: const _VerticalBarThumbShape(),
-        tickMarkShape: const RoundSliderTickMarkShape(tickMarkRadius: 3),
-        activeTickMarkColor: Theme.of(context).colorScheme.onPrimary,
-        inactiveTickMarkColor: Theme.of(context).colorScheme.primary,
-        overlayShape: const RoundSliderOverlayShape(overlayRadius: 20),
-      ),
-      child: Slider(
-        value: settingsProvider.updateIntervalSliderVal.roundToDouble().clamp(
-          0,
-          updateIntervalNodes.length.toDouble(),
-        ),
-        max: updateIntervalNodes.length.toDouble(),
-        divisions: updateIntervalNodes.length,
-        label: updateIntervalLabel,
-        onChanged: (double value) {
-          setState(() {
-            settingsProvider.updateIntervalSliderVal = value;
-            processIntervalSliderValue(value);
-          });
-        },
-        onChangeEnd: (double value) {
-          setState(() {
-            settingsProvider.updateInterval = updateInterval;
-          });
-        },
-      ),
-    );
-
-    final List<Widget> sourceSpecificForms = sourceProvider.sources
-        .where((s) => s.sourceConfigSettingFormItems.isNotEmpty)
-        .map((source) {
-          return GeneratedForm(
-            outlinedInputFields: true,
-            items: source.sourceConfigSettingFormItems.map((item) {
-              final GeneratedFormItem formItem = item.clone();
-              if (formItem is GeneratedFormSwitch) {
-                formItem.defaultValue = settingsProvider.getSettingBool(
-                  formItem.key,
-                );
-              } else {
-                formItem.defaultValue = settingsProvider.getSettingString(
-                  formItem.key,
-                );
-              }
-              return [formItem];
-            }).toList(),
-            onValueChanges: (values, valid, isBuilding) {
-              if (valid && !isBuilding) {
-                if (source is GitHub) {
-                  final String? githubCreds = values[GitHub.githubCredsKey]
-                      ?.toString();
-                  if (!GitHub.hasValidatedPAT(githubCreds, settingsProvider)) {
-                    GitHub.clearPATValidation(settingsProvider);
-                  }
-                }
-                values.forEach((key, value) {
-                  final formItem = source.sourceConfigSettingFormItems
-                      .where((i) => i.key == key)
-                      .firstOrNull;
-                  if (formItem is GeneratedFormSwitch) {
-                    settingsProvider.setSettingBool(key, value == true);
-                  } else {
-                    settingsProvider.setSettingString(key, value ?? '');
-                  }
-                });
-              }
-            },
-          );
-        })
-        .toList();
-
-    final cs = Theme.of(context).colorScheme;
-
-    final Widget updatesIntervalHead = Padding(
-      padding: const EdgeInsets.fromLTRB(16, 8, 8, 8),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          Icon(Icons.update_rounded, color: cs.onSurfaceVariant),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 8),
-                  child: Row(
-                    children: [
-                      Expanded(child: Text(tr('bgUpdateCheckInterval'))),
-                      Text(updateIntervalLabel),
-                    ],
-                  ),
-                ),
-                intervalSlider,
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
+      );
+    }
 
     Widget sectionHeader(String title, IconData icon, String key) {
-      final bool expanded =
-          settingsProvider.prefs?.getBool('settingsSection_$key') ?? true;
+      final bool expanded = expandedState[key] ?? true;
       const Duration headerTransitionDuration = Duration(milliseconds: 300);
       const Curve headerTransitionCurve = Curves.easeInOutCubicEmphasized;
       final Color collapsedHeaderColor = Color.lerp(
@@ -546,10 +209,7 @@ class _SettingsPageState extends State<SettingsPage> {
           child: Material(
             type: MaterialType.transparency,
             child: InkWell(
-              onTap: () => settingsProvider.setSettingBool(
-                'settingsSection_$key',
-                !expanded,
-              ),
+              onTap: () => setSectionExpanded(key, !expanded),
               borderRadius: BorderRadius.circular(expanded ? 8 : 28),
               splashFactory: NoSplash.splashFactory,
               splashColor: Colors.transparent,
@@ -673,66 +333,12 @@ class _SettingsPageState extends State<SettingsPage> {
       );
     }
 
-    Widget settingsCard(List<Widget> children) {
-      return m3eExpressiveSettingsCard(
-        context: context,
-        colorScheme: cs,
-        items: children,
-      );
-    }
-
-    Widget collapsibleCard(String key, List<Widget> children) {
-      final bool expanded =
-          settingsProvider.prefs?.getBool('settingsSection_$key') ?? true;
-      return ClipRect(
-        clipper: _SettingsSectionShadowClipper(expanded: expanded),
-        child: AnimatedAlign(
-          duration: const Duration(milliseconds: 360),
-          curve: Curves.easeInOutCubicEmphasized,
-          alignment: Alignment.topCenter,
-          heightFactor: expanded ? 1.0 : 0.0,
-          child: AnimatedOpacity(
-            duration: Duration(milliseconds: expanded ? 260 : 140),
-            curve: expanded ? Curves.easeOutCubic : Curves.easeInCubic,
-            opacity: expanded ? 1.0 : 0.0,
-            child: settingsCard(children),
-          ),
-        ),
-      );
-    }
-
-    final List<String> visibleSettingsSectionKeys = [
-      'updates',
-      if (sourceProvider.sources.any(
-        (source) => source.sourceConfigSettingFormItems.isNotEmpty,
-      ))
-        'sourceSpecific',
-      'themes',
-      'appearance',
-      'gestures',
-      'categories',
-    ];
-    final bool allSettingsSectionsExpanded = visibleSettingsSectionKeys.every(
-      (sectionKey) =>
-          settingsProvider.prefs?.getBool('settingsSection_$sectionKey') ??
-          true,
-    );
-
-    void setAllSettingsSectionsExpanded(bool expanded) {
-      for (final sectionKey in _settingsSectionKeys) {
-        settingsProvider.setSettingBool(
-          'settingsSection_$sectionKey',
-          expanded,
-        );
-      }
-    }
-
     return Scaffold(
       backgroundColor: cs.surface,
       body: Stack(
         fit: StackFit.expand,
         children: [
-          if (settingsProvider.useGradientBackground)
+          if (sp.useGradientBackground)
             Positioned.fill(
               child: DecoratedBox(
                 decoration: BoxDecoration(
@@ -756,7 +362,7 @@ class _SettingsPageState extends State<SettingsPage> {
             slivers: <Widget>[
               CustomAppBar(
                 title: tr('settings'),
-                matchGradientBackground: settingsProvider.useGradientBackground,
+                matchGradientBackground: sp.useGradientBackground,
                 actions: [
                   IconButton(
                     tooltip: allSettingsSectionsExpanded
@@ -778,37 +384,25 @@ class _SettingsPageState extends State<SettingsPage> {
               SliverToBoxAdapter(
                 child: Padding(
                   padding: const EdgeInsets.all(16),
-                  child: settingsProvider.prefs == null
+                  child: sp.prefs == null
                       ? const SizedBox()
                       : Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            // ── Updates ──────────────────────────────────────────
+                            // ── Updates ───────────────────────────────────
                             sectionHeader(
                               tr('updates'),
                               Icons.update_rounded,
                               'updates',
                             ),
-                            FutureBuilder<AndroidDeviceInfo>(
-                              future: _androidInfo,
-                              builder:
-                                  (
-                                    BuildContext context,
-                                    AsyncSnapshot<AndroidDeviceInfo> snapshot,
-                                  ) {
-                                    return collapsibleCard(
-                                      'updates',
-                                      _updatesCardItemList(
-                                        context,
-                                        cs,
-                                        settingsProvider,
-                                        snapshot,
-                                        updatesIntervalHead,
-                                      ),
-                                    );
-                                  },
+                            collapsibleCard(
+                              'updates',
+                              _UpdatesSection(
+                                cs: cs,
+                                androidInfo: _androidInfo,
+                              ),
                             ),
-                            // ── Source-specific ──────────────────────────────────
+                            // ── Source-specific ───────────────────────────
                             if (sourceProvider.sources.any(
                               (s) => s.sourceConfigSettingFormItems.isNotEmpty,
                             )) ...[
@@ -817,32 +411,12 @@ class _SettingsPageState extends State<SettingsPage> {
                                 Icons.dns_rounded,
                                 'sourceSpecific',
                               ),
-                              collapsibleCard('sourceSpecific', [
-                                Padding(
-                                  padding: const EdgeInsets.fromLTRB(
-                                    16,
-                                    8,
-                                    16,
-                                    8,
-                                  ),
-                                  child: Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.stretch,
-                                    children: [
-                                      for (
-                                        int i = 0;
-                                        i < sourceSpecificForms.length;
-                                        i++
-                                      ) ...[
-                                        if (i > 0) const SizedBox(height: 12),
-                                        sourceSpecificForms[i],
-                                      ],
-                                    ],
-                                  ),
-                                ),
-                              ]),
+                              collapsibleCard(
+                                'sourceSpecific',
+                                const _SourceSpecificSection(),
+                              ),
                             ],
-                            // ── Themes ────────────────────────────────────────────
+                            // ── Themes ───────────────────────────────────
                             sectionHeader(
                               tr('settingsThemesSection'),
                               Icons.palette_rounded,
@@ -850,409 +424,51 @@ class _SettingsPageState extends State<SettingsPage> {
                             ),
                             collapsibleCard(
                               'themes',
-                              buildThemesSettingsCardItems(
-                                context,
-                                _androidInfo,
+                              _ThemesSettingsSection(
+                                androidInfoFuture: _androidInfo,
                               ),
                             ),
-                            // ── Appearance ────────────────────────────────────────
+                            // ── Appearance ────────────────────────────────
                             sectionHeader(
                               tr('appearance'),
                               Icons.tune_rounded,
                               'appearance',
                             ),
-                            collapsibleCard('appearance', [
-                              Padding(
-                                padding: const EdgeInsets.fromLTRB(
-                                  16,
-                                  12,
-                                  16,
-                                  4,
-                                ),
-                                child: localeMenu,
+                            collapsibleCard(
+                              'appearance',
+                              _AppearanceSection(
+                                androidInfo: _androidInfo,
                               ),
-                              FutureBuilder(
-                                builder: (ctx, val) {
-                                  return (val.data?.version.sdkInt ?? 0) >= 29
-                                      ? SwitchListTile(
-                                          title: Text(tr('useSystemFont')),
-                                          value: settingsProvider.useSystemFont,
-                                          onChanged: (useSystemFont) {
-                                            if (useSystemFont) {
-                                              NativeFeatures.loadSystemFont()
-                                                  .then((val) {
-                                                    settingsProvider
-                                                            .useSystemFont =
-                                                        true;
-                                                  });
-                                            } else {
-                                              settingsProvider.useSystemFont =
-                                                  false;
-                                            }
-                                          },
-                                        )
-                                      : const SizedBox.shrink();
-                                },
-                                future: _androidInfo,
-                              ),
-                              // ── UI scale slider ─────────────────────────
-                              // Lets users dial the in-app text/layout size
-                              // up or down. The slider is the sole knob -
-                              // when it's at 1.0 the MediaQuery override in
-                              // main.dart is a true no-op. Visual design
-                              // mirrors the [intervalSlider] above (gapped
-                              // track + vertical-bar thumb + tick marks)
-                              // for consistency across the settings page.
-                              Padding(
-                                padding: const EdgeInsets.fromLTRB(16, 8, 8, 8),
-                                child: Row(
-                                  crossAxisAlignment: CrossAxisAlignment.center,
-                                  children: [
-                                    Icon(
-                                      Icons.format_size_rounded,
-                                      color: Theme.of(
-                                        context,
-                                      ).colorScheme.onSurfaceVariant,
-                                    ),
-                                    const SizedBox(width: 8),
-                                    Expanded(
-                                      child: Column(
-                                        crossAxisAlignment:
-                                            CrossAxisAlignment.start,
-                                        children: [
-                                          Padding(
-                                            padding: const EdgeInsets.symmetric(
-                                              horizontal: 8,
-                                            ),
-                                            child: Row(
-                                              children: [
-                                                Expanded(
-                                                  child: Text(tr('uiScale')),
-                                                ),
-                                                Text(
-                                                  '${(settingsProvider.appUiScale * 100).round()}%',
-                                                ),
-                                              ],
-                                            ),
-                                          ),
-                                          SliderTheme(
-                                            data: SliderTheme.of(context).copyWith(
-                                              trackHeight: 16,
-                                              trackShape:
-                                                  const _GappedTrackShape(),
-                                              thumbShape:
-                                                  const _VerticalBarThumbShape(),
-                                              tickMarkShape:
-                                                  const RoundSliderTickMarkShape(
-                                                    tickMarkRadius: 3,
-                                                  ),
-                                              activeTickMarkColor: Theme.of(
-                                                context,
-                                              ).colorScheme.onPrimary,
-                                              inactiveTickMarkColor: Theme.of(
-                                                context,
-                                              ).colorScheme.primary,
-                                              overlayShape:
-                                                  const RoundSliderOverlayShape(
-                                                    overlayRadius: 20,
-                                                  ),
-                                            ),
-                                            child: Slider(
-                                              min: SettingsProvider
-                                                  .appUiScaleMin,
-                                              max: SettingsProvider
-                                                  .appUiScaleMax,
-                                              divisions:
-                                                  ((SettingsProvider
-                                                                  .appUiScaleMax -
-                                                              SettingsProvider
-                                                                  .appUiScaleMin) /
-                                                          0.05)
-                                                      .round(),
-                                              label:
-                                                  '${(settingsProvider.appUiScale * 100).round()}%',
-                                              value:
-                                                  settingsProvider.appUiScale,
-                                              onChanged: (double value) {
-                                                settingsProvider.appUiScale =
-                                                    value;
-                                              },
-                                            ),
-                                          ),
-                                        ],
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                              Padding(
-                                padding: const EdgeInsets.fromLTRB(16, 8, 8, 8),
-                                child: Row(
-                                  crossAxisAlignment: CrossAxisAlignment.center,
-                                  children: [
-                                    Icon(
-                                      Icons.rounded_corner_rounded,
-                                      color: Theme.of(
-                                        context,
-                                      ).colorScheme.onSurfaceVariant,
-                                    ),
-                                    const SizedBox(width: 8),
-                                    Expanded(
-                                      child: Column(
-                                        crossAxisAlignment:
-                                            CrossAxisAlignment.start,
-                                        children: [
-                                          Padding(
-                                            padding: const EdgeInsets.symmetric(
-                                              horizontal: 8,
-                                            ),
-                                            child: Row(
-                                              children: [
-                                                Expanded(
-                                                  child: Text(
-                                                    tr('cardCorners'),
-                                                  ),
-                                                ),
-                                                Text(
-                                                  '${(settingsProvider.cardCornerScale * 100).round()}%',
-                                                ),
-                                              ],
-                                            ),
-                                          ),
-                                          SliderTheme(
-                                            data: SliderTheme.of(context).copyWith(
-                                              trackHeight: 16,
-                                              trackShape:
-                                                  const _GappedTrackShape(),
-                                              thumbShape:
-                                                  const _VerticalBarThumbShape(),
-                                              tickMarkShape:
-                                                  const RoundSliderTickMarkShape(
-                                                    tickMarkRadius: 3,
-                                                  ),
-                                              activeTickMarkColor: Theme.of(
-                                                context,
-                                              ).colorScheme.onPrimary,
-                                              inactiveTickMarkColor: Theme.of(
-                                                context,
-                                              ).colorScheme.primary,
-                                              overlayShape:
-                                                  const RoundSliderOverlayShape(
-                                                    overlayRadius: 20,
-                                                  ),
-                                            ),
-                                            child: Slider(
-                                              min: SettingsProvider
-                                                  .cardCornerScaleMin,
-                                              max: SettingsProvider
-                                                  .cardCornerScaleMax,
-                                              divisions:
-                                                  ((SettingsProvider
-                                                                  .cardCornerScaleMax -
-                                                              SettingsProvider
-                                                                  .cardCornerScaleMin) /
-                                                          0.10)
-                                                      .round(),
-                                              label:
-                                                  '${(settingsProvider.cardCornerScale * 100).round()}%',
-                                              value: settingsProvider
-                                                  .cardCornerScale,
-                                              onChanged: (double value) {
-                                                settingsProvider
-                                                        .cardCornerScale =
-                                                    value;
-                                              },
-                                            ),
-                                          ),
-                                        ],
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                              SwitchListTile(
-                                title: Text(tr('showWebInAppView')),
-                                value: settingsProvider.showAppWebpage,
-                                onChanged: (value) {
-                                  settingsProvider.showAppWebpage = value;
-                                },
-                              ),
-                              // [showFolderedAppsOnMainPage] toggle moved
-                              // to the apps-list view options sheet (open
-                              // via the apps tab's filter / view-options
-                              // entry point) - it's a main-tab-scoped
-                              // setting and belongs alongside the other
-                              // view options (sort / group / pin updates
-                              // etc.) rather than in the global Settings
-                              // page where it competed with truly app-wide
-                              // controls. See [showAppsViewOptionsSheet].
-                              SwitchListTile(
-                                title: Text(tr('dontShowTrackOnlyWarnings')),
-                                value: settingsProvider.hideTrackOnlyWarning,
-                                onChanged: (value) {
-                                  settingsProvider.hideTrackOnlyWarning = value;
-                                },
-                              ),
-                              SwitchListTile(
-                                title: Text(tr('dontShowAPKOriginWarnings')),
-                                value: settingsProvider.hideAPKOriginWarning,
-                                onChanged: (value) {
-                                  settingsProvider.hideAPKOriginWarning = value;
-                                },
-                              ),
-                              SwitchListTile(
-                                title: Text(tr('disablePageTransitions')),
-                                value: settingsProvider.disablePageTransitions,
-                                onChanged: (value) {
-                                  settingsProvider.disablePageTransitions =
-                                      value;
-                                },
-                              ),
-                              SwitchListTile(
-                                title: Text(tr('reversePageTransitions')),
-                                value: settingsProvider.reversePageTransitions,
-                                onChanged:
-                                    settingsProvider.disablePageTransitions
-                                    ? null
-                                    : (value) {
-                                        settingsProvider
-                                                .reversePageTransitions =
-                                            value;
-                                      },
-                              ),
-                              SwitchListTile(
-                                title: Text(tr('highlightTouchTargets')),
-                                value: settingsProvider.highlightTouchTargets,
-                                onChanged: (value) {
-                                  settingsProvider.highlightTouchTargets =
-                                      value;
-                                },
-                              ),
-                            ]),
-                            // ── Gestures ──────────────────────────────────────────
+                            ),
+                            // ── Gestures ─────────────────────────────────
                             sectionHeader(
                               tr('gestures'),
                               Icons.swipe_rounded,
                               'gestures',
                             ),
-                            collapsibleCard('gestures', [
-                              Padding(
-                                padding: const EdgeInsets.fromLTRB(
-                                  16,
-                                  12,
-                                  16,
-                                  12,
-                                ),
-                                child: (() {
-                                  final List<SwipeAction> actions =
-                                      swipeActionsSortedByLocalizedLabel();
-                                  final double swipeMenuWidth =
-                                      appDropdownMenuWidth(
-                                        context,
-                                        actions.map(
-                                          (SwipeAction action) =>
-                                              tr('swipeAction_${action.name}'),
-                                        ),
-                                        style: Theme.of(
-                                          context,
-                                        ).textTheme.bodyLarge,
-                                        horizontalPadding: 120,
-                                        minWidth: 180,
-                                        maxWidthInset: 80,
-                                      );
-                                  List<DropdownMenuItem<SwipeAction>>
-                                  actionItems() {
-                                    return actions.map((SwipeAction action) {
-                                      return DropdownMenuItem<SwipeAction>(
-                                        value: action,
-                                        child: Row(
-                                          mainAxisSize: MainAxisSize.min,
-                                          children: [
-                                            Icon(
-                                              _swipeActionIcon(action),
-                                              size: 18,
-                                            ),
-                                            const SizedBox(width: 12),
-                                            Text(
-                                              tr('swipeAction_${action.name}'),
-                                            ),
-                                          ],
-                                        ),
-                                      );
-                                    }).toList();
-                                  }
-
-                                  return Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.stretch,
-                                    children: [
-                                      appDropdownField<SwipeAction>(
-                                        key: ValueKey(
-                                          'rightSwipeAction_${settingsProvider.rightSwipeAction}',
-                                        ),
-                                        context: context,
-                                        value:
-                                            settingsProvider.rightSwipeAction,
-                                        labelText: tr('rightSwipeAction'),
-                                        menuWidth: swipeMenuWidth,
-                                        items: actionItems(),
-                                        onChanged: (SwipeAction? value) {
-                                          if (value != null) {
-                                            settingsProvider.rightSwipeAction =
-                                                value;
-                                          }
-                                        },
-                                      ),
-                                      const SizedBox(height: 16),
-                                      appDropdownField<SwipeAction>(
-                                        key: ValueKey(
-                                          'leftSwipeAction_${settingsProvider.leftSwipeAction}',
-                                        ),
-                                        context: context,
-                                        value: settingsProvider.leftSwipeAction,
-                                        labelText: tr('leftSwipeAction'),
-                                        menuWidth: swipeMenuWidth,
-                                        items: actionItems(),
-                                        onChanged: (SwipeAction? value) {
-                                          if (value != null) {
-                                            settingsProvider.leftSwipeAction =
-                                                value;
-                                          }
-                                        },
-                                      ),
-                                    ],
-                                  );
-                                })(),
-                              ),
-                            ]),
-                            // ── Categories ────────────────────────────────────────
+                            collapsibleCard(
+                              'gestures',
+                              const _GesturesSection(),
+                            ),
+                            // ── Categories ───────────────────────────────
                             sectionHeader(
                               tr('categories'),
                               Icons.label_rounded,
                               'categories',
                             ),
-                            collapsibleCard('categories', [
-                              const Padding(
-                                padding: EdgeInsets.all(16),
-                                child: CategoryEditorSelector(
-                                  showLabelWhenNotEmpty: false,
-                                  showSelectedCheckmark: true,
-                                  showChangeIntentIcons: false,
-                                ),
-                              ),
-                            ]),
+                            collapsibleCard(
+                              'categories',
+                              const _CategoriesSection(),
+                            ),
                             aboutSectionHeader(),
                             settingsCard([
-                              _AboutSectionContent(
-                                colorScheme: cs,
-                                settingsProvider: settingsProvider,
-                              ),
+                              _AboutSectionContent(colorScheme: cs),
                             ]),
                           ],
                         ),
                 ),
               ),
-              if (settingsProvider.progressiveBlurEnabled)
+              if (sp.progressiveBlurEnabled)
                 SliverToBoxAdapter(
                   child: SizedBox(height: MediaQuery.paddingOf(context).bottom),
                 ),
@@ -1290,17 +506,901 @@ class _SettingsSectionShadowClipper extends CustomClipper<Rect> {
   }
 }
 
-class _AboutSectionContent extends StatelessWidget {
-  const _AboutSectionContent({
-    required this.colorScheme,
-    required this.settingsProvider,
+// ── Section widgets ─────────────────────────────────────────────────────
+
+/// Updates section with its own narrow provider subscription.
+/// Only rebuilds when update-related settings change.
+class _UpdatesSection extends StatelessWidget {
+  const _UpdatesSection({
+    required this.cs,
+    required this.androidInfo,
   });
 
-  final ColorScheme colorScheme;
-  final SettingsProvider settingsProvider;
+  final ColorScheme cs;
+  final Future<AndroidDeviceInfo> androidInfo;
+
+  static int _updateSettingsHash(SettingsProvider sp) => Object.hash(
+        sp.updateInterval,
+        sp.updateIntervalSliderVal,
+        sp.useFGService,
+        sp.enableBackgroundUpdates,
+        sp.bgUpdatesOnWiFiOnly,
+        sp.bgUpdatesWhileChargingOnly,
+        sp.checkOnStart,
+        sp.checkUpdateOnDetailPage,
+        sp.onlyCheckInstalledOrTrackOnlyApps,
+        sp.removeOnExternalUninstall,
+        sp.parallelDownloads,
+        sp.beforeNewInstallsShareToAppVerifier,
+        sp.installerMode,
+        sp.shizukuPretendToBeGooglePlay,
+      );
 
   @override
   Widget build(BuildContext context) {
+    // Narrow watch — only rebuild when update-related settings change.
+    context.select<SettingsProvider, int>(_updateSettingsHash);
+    final SettingsProvider sp = context.read<SettingsProvider>();
+
+    return FutureBuilder<AndroidDeviceInfo>(
+      future: androidInfo,
+      builder: (context, snapshot) {
+        return _buildSettingsCardContent(context, sp, cs, snapshot);
+      },
+    );
+  }
+
+  Widget _buildSettingsCardContent(
+    BuildContext context,
+    SettingsProvider sp,
+    ColorScheme cs,
+    AsyncSnapshot<AndroidDeviceInfo> snapshot,
+  ) {
+    final List<Widget> rows = <Widget>[
+      _UpdateIntervalSlider(cs: cs),
+    ];
+    final bool showBgControls =
+        (sp.updateInterval > 0) &&
+        (((snapshot.data?.version.sdkInt ?? 0) >= 30) ||
+            sp.installerMode == 'shizuku' ||
+            sp.enableBackgroundUpdates);
+    if (showBgControls) {
+      rows
+        ..add(
+          ListTile(
+            title: Text(tr('foregroundServiceForUpdateChecking')),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                HelpHintIcon(
+                  message: tr('foregroundServiceReliabilityNote'),
+                  padding: EdgeInsets.zero,
+                ),
+                Switch(
+                  value: sp.useFGService,
+                  onChanged: (bool value) => sp.useFGService = value,
+                ),
+              ],
+            ),
+            onTap: () => sp.useFGService = !sp.useFGService,
+          ),
+        )
+        ..add(
+          ListTile(
+            title: Text(tr('enableBackgroundUpdates')),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                HelpHintIcon(
+                  message:
+                      '${tr('backgroundUpdateReqsExplanation')}\n\n${tr('backgroundUpdateLimitsExplanation')}',
+                  padding: EdgeInsets.zero,
+                ),
+                Switch(
+                  value: sp.enableBackgroundUpdates,
+                  onChanged: (bool value) => sp.enableBackgroundUpdates = value,
+                ),
+              ],
+            ),
+            onTap: () => sp.enableBackgroundUpdates =
+                !sp.enableBackgroundUpdates,
+          ),
+        );
+      if (sp.enableBackgroundUpdates) {
+        rows
+          ..add(
+            SwitchListTile(
+              title: Text(tr('bgUpdatesOnWiFiOnly')),
+              value: sp.bgUpdatesOnWiFiOnly,
+              onChanged: (bool value) => sp.bgUpdatesOnWiFiOnly = value,
+            ),
+          )
+          ..add(
+            SwitchListTile(
+              title: Text(tr('bgUpdatesWhileChargingOnly')),
+              value: sp.bgUpdatesWhileChargingOnly,
+              onChanged: (bool value) => sp.bgUpdatesWhileChargingOnly = value,
+            ),
+          );
+      }
+    }
+    rows.addAll(<Widget>[
+      SwitchListTile(
+        title: Text(tr('checkOnStart')),
+        value: sp.checkOnStart,
+        onChanged: (bool value) => sp.checkOnStart = value,
+      ),
+      SwitchListTile(
+        title: Text(tr('checkUpdateOnDetailPage')),
+        value: sp.checkUpdateOnDetailPage,
+        onChanged: (bool value) => sp.checkUpdateOnDetailPage = value,
+      ),
+      SwitchListTile(
+        title: Text(tr('onlyCheckInstalledOrTrackOnlyApps')),
+        value: sp.onlyCheckInstalledOrTrackOnlyApps,
+        onChanged: (bool value) => sp.onlyCheckInstalledOrTrackOnlyApps = value,
+      ),
+      SwitchListTile(
+        title: Text(tr('removeOnExternalUninstall')),
+        value: sp.removeOnExternalUninstall,
+        onChanged: (bool value) => sp.removeOnExternalUninstall = value,
+      ),
+      SwitchListTile(
+        title: Text(tr('parallelDownloads')),
+        value: sp.parallelDownloads,
+        onChanged: (bool value) => sp.parallelDownloads = value,
+      ),
+      ListTile(
+        title: Text(tr('beforeNewInstallsShareToAppVerifier')),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              tooltip: tr('about'),
+              onPressed: () {
+                launchUrlString(
+                  'https://github.com/soupslurpr/AppVerifier',
+                  mode: LaunchMode.externalApplication,
+                );
+              },
+              style: IconButton.styleFrom(
+                foregroundColor: cs.onSurfaceVariant,
+                iconSize: 20,
+                padding: const EdgeInsets.all(4),
+                minimumSize: const Size(32, 32),
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                visualDensity: VisualDensity.compact,
+              ),
+              icon: const Icon(Icons.open_in_new_rounded),
+            ),
+            Switch(
+              value: sp.beforeNewInstallsShareToAppVerifier,
+              onChanged: (bool value) =>
+                  sp.beforeNewInstallsShareToAppVerifier = value,
+            ),
+          ],
+        ),
+      ),
+      Padding(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(tr('installerMode')),
+            const SizedBox(height: 4),
+            SizedBox(
+              width: double.infinity,
+              child: SegmentedButton<String>(
+                segments: [
+                  ButtonSegment<String>(
+                    value: 'stock',
+                    label: Text(tr('installerModeStock')),
+                  ),
+                  ButtonSegment<String>(
+                    value: 'shizuku',
+                    label: Text(tr('installerModeShizuku')),
+                  ),
+                  ButtonSegment<String>(
+                    value: 'legacy',
+                    label: Text(tr('installerModeThirdParty')),
+                  ),
+                ],
+                selected: {sp.installerMode},
+                onSelectionChanged: (Set<String> selected) {
+                  final String mode = selected.first;
+                  if (mode == 'shizuku') {
+                    ShizukuApkInstaller().checkPermission().then(
+                      (String? resCode) {
+                        if (!context.mounted) return;
+                        if (resCode!.startsWith('granted')) {
+                          sp.installerMode = 'shizuku';
+                        } else {
+                          switch (resCode) {
+                            case 'services_not_found':
+                              showError(
+                                ObtainiumError(tr('shizukuBinderNotFound')),
+                                context,
+                              );
+                            case 'old_shizuku':
+                              showError(
+                                ObtainiumError(tr('shizukuOld')),
+                                context,
+                              );
+                            case 'old_android_with_adb':
+                              showError(
+                                ObtainiumError(
+                                  tr('shizukuOldAndroidWithADB'),
+                                ),
+                                context,
+                              );
+                            case 'denied':
+                              showError(
+                                ObtainiumError(tr('cancelled')),
+                                context,
+                              );
+                          }
+                        }
+                      },
+                    );
+                  } else {
+                    sp.installerMode = mode;
+                  }
+                },
+              ),
+            ),
+            if (sp.installerMode == 'shizuku')
+              SwitchListTile(
+                contentPadding: EdgeInsets.zero,
+                title: Text(tr('shizukuPretendToBeGooglePlay')),
+                value: sp.shizukuPretendToBeGooglePlay,
+                onChanged: (bool value) =>
+                    sp.shizukuPretendToBeGooglePlay = value,
+              ),
+            if (sp.installerMode == 'legacy')
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: _ThirdPartyInstallerSelector(settingsProvider: sp),
+              ),
+          ],
+        ),
+      ),
+    ]);
+    return m3eExpressiveSettingsCard(
+      context: context,
+      colorScheme: cs,
+      items: rows,
+    );
+  }
+}
+
+/// Update-interval slider — a StatefulWidget so drag updates use local state.
+/// The SettingsProvider is only written to when the user lifts their finger
+/// (onChangeEnd), avoiding a notifyListeners → full-page rebuild on every
+/// slider tick during drag.
+class _UpdateIntervalSlider extends StatefulWidget {
+  const _UpdateIntervalSlider({required this.cs});
+
+  final ColorScheme cs;
+
+  @override
+  State<_UpdateIntervalSlider> createState() => _UpdateIntervalSliderState();
+}
+
+class _UpdateIntervalSliderState extends State<_UpdateIntervalSlider> {
+  late double _localSliderVal;
+  late int _localInterval;
+  late String _localLabel;
+  bool _initializing = true;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final SettingsProvider sp = context.read<SettingsProvider>();
+    if (_initializing) {
+      _localSliderVal = sp.updateIntervalSliderVal;
+      _updateLabel(_localSliderVal);
+      _initializing = false;
+    }
+  }
+
+  void _updateLabel(double val) {
+    final int index = val.round().clamp(0, _SettingsPageState.updateIntervalNodes.length);
+    if (index == 0) {
+      _localInterval = 0;
+      _localLabel = tr('neverManualOnly');
+      return;
+    }
+    final int minutes = _SettingsPageState.updateIntervalNodes[index - 1];
+    _localInterval = minutes;
+    if (minutes < 60) {
+      _localLabel = plural('minute', minutes);
+    } else if (minutes < 24 * 60) {
+      _localLabel = plural('hour', minutes ~/ 60);
+    } else {
+      _localLabel = plural('day', minutes ~/ (24 * 60));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 8, 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Icon(Icons.update_rounded, color: widget.cs.onSurfaceVariant),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: Row(
+                    children: [
+                      Expanded(child: Text(tr('bgUpdateCheckInterval'))),
+                      Text(_localLabel),
+                    ],
+                  ),
+                ),
+                SliderTheme(
+                  data: SliderTheme.of(context).copyWith(
+                    trackHeight: 16,
+                    trackShape: const _GappedTrackShape(),
+                    thumbShape: const _VerticalBarThumbShape(),
+                    tickMarkShape: const RoundSliderTickMarkShape(tickMarkRadius: 3),
+                    activeTickMarkColor: Theme.of(context).colorScheme.onPrimary,
+                    inactiveTickMarkColor: Theme.of(context).colorScheme.primary,
+                    overlayShape: const RoundSliderOverlayShape(overlayRadius: 20),
+                  ),
+                  child: Slider(
+                    value: _localSliderVal.clamp(
+                      0,
+                      _SettingsPageState.updateIntervalNodes.length.toDouble(),
+                    ),
+                    max: _SettingsPageState.updateIntervalNodes.length.toDouble(),
+                    divisions: _SettingsPageState.updateIntervalNodes.length,
+                    label: _localLabel,
+                    onChanged: (double value) {
+                      setState(() {
+                        _localSliderVal = value;
+                        _updateLabel(value);
+                      });
+                    },
+                    onChangeEnd: (double value) {
+                      final SettingsProvider sp = context.read<SettingsProvider>();
+                      setState(() {
+                        sp.updateIntervalSliderVal = value;
+                        sp.updateInterval = _localInterval;
+                      });
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Source-specific settings section — reads/writes generic source config.
+class _SourceSpecificSection extends StatelessWidget {
+  const _SourceSpecificSection();
+
+  @override
+  Widget build(BuildContext context) {
+    // Subscribe to any change in stored source settings.
+    context.select<SettingsProvider, bool>((s) => s.prefs != null);
+    final SettingsProvider sp = context.read<SettingsProvider>();
+    final SourceProvider sourceProvider = SourceProvider();
+    final ColorScheme cs = Theme.of(context).colorScheme;
+
+    final sources = sourceProvider.sources
+        .where((s) => s.sourceConfigSettingFormItems.isNotEmpty)
+        .toList();
+
+    final forms = sources.map((source) {
+      return GeneratedForm(
+        outlinedInputFields: true,
+        items: source.sourceConfigSettingFormItems.map((item) {
+          final formItem = item.clone();
+          if (formItem is GeneratedFormSwitch) {
+            formItem.defaultValue = sp.getSettingBool(formItem.key);
+          } else {
+            formItem.defaultValue = sp.getSettingString(formItem.key);
+          }
+          return [formItem];
+        }).toList(),
+        onValueChanges: (values, valid, isBuilding) {
+          if (valid && !isBuilding) {
+            if (source is GitHub) {
+              final String? githubCreds = values[GitHub.githubCredsKey]
+                  ?.toString();
+              if (!GitHub.hasValidatedPAT(githubCreds, sp)) {
+                GitHub.clearPATValidation(sp);
+              }
+            }
+            values.forEach((key, value) {
+              final formItem = source.sourceConfigSettingFormItems
+                  .where((i) => i.key == key)
+                  .firstOrNull;
+              if (formItem is GeneratedFormSwitch) {
+                sp.setSettingBool(key, value == true);
+              } else {
+                sp.setSettingString(key, value ?? '');
+              }
+            });
+          }
+        },
+      );
+    }).toList();
+
+    return m3eExpressiveSettingsCard(
+      context: context,
+      colorScheme: cs,
+      items: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              for (int i = 0; i < forms.length; i++) ...[
+                if (i > 0) const SizedBox(height: 12),
+                forms[i],
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Themes section — delegates to external themes settings widget,
+/// using the existing optimized context.select pattern.
+class _ThemesSettingsSection extends StatelessWidget {
+  const _ThemesSettingsSection({required this.androidInfoFuture});
+
+  final Future<AndroidDeviceInfo> androidInfoFuture;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme cs = Theme.of(context).colorScheme;
+    return m3eExpressiveSettingsCard(
+      context: context,
+      colorScheme: cs,
+      items: buildThemesSettingsCardItems(context, androidInfoFuture),
+    );
+  }
+}
+
+/// Appearance section — locale, UI scale slider, card-corner slider, toggles.
+class _AppearanceSection extends StatelessWidget {
+  const _AppearanceSection({required this.androidInfo});
+
+  final Future<AndroidDeviceInfo> androidInfo;
+
+  static int _appearanceSettingsHash(SettingsProvider sp) => Object.hash(
+        sp.forcedLocale?.toLanguageTag(),
+        sp.useSystemFont,
+        sp.appUiScale,
+        sp.cardCornerScale,
+        sp.showAppWebpage,
+        sp.hideTrackOnlyWarning,
+        sp.hideAPKOriginWarning,
+        sp.disablePageTransitions,
+        sp.reversePageTransitions,
+        sp.highlightTouchTargets,
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    context.select<SettingsProvider, int>(_appearanceSettingsHash);
+    final SettingsProvider sp = context.read<SettingsProvider>();
+    final ColorScheme cs = Theme.of(context).colorScheme;
+
+    return m3eExpressiveSettingsCard(
+      context: context,
+      colorScheme: cs,
+      items: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+          child: _LocaleMenu(sp: sp),
+        ),
+        FutureBuilder(
+          builder: (ctx, val) {
+            return (val.data?.version.sdkInt ?? 0) >= 29
+                ? SwitchListTile(
+                    title: Text(tr('useSystemFont')),
+                    value: sp.useSystemFont,
+                    onChanged: (useSystemFont) {
+                      if (useSystemFont) {
+                        NativeFeatures.loadSystemFont().then((_) {
+                          sp.useSystemFont = true;
+                        });
+                      } else {
+                        sp.useSystemFont = false;
+                      }
+                    },
+                  )
+                : const SizedBox.shrink();
+          },
+          future: androidInfo,
+        ),
+        _UiScaleSlider(sp: sp),
+        _CardCornerScaleSlider(sp: sp),
+        SwitchListTile(
+          title: Text(tr('showWebInAppView')),
+          value: sp.showAppWebpage,
+          onChanged: (value) => sp.showAppWebpage = value,
+        ),
+        SwitchListTile(
+          title: Text(tr('dontShowTrackOnlyWarnings')),
+          value: sp.hideTrackOnlyWarning,
+          onChanged: (value) => sp.hideTrackOnlyWarning = value,
+        ),
+        SwitchListTile(
+          title: Text(tr('dontShowAPKOriginWarnings')),
+          value: sp.hideAPKOriginWarning,
+          onChanged: (value) => sp.hideAPKOriginWarning = value,
+        ),
+        SwitchListTile(
+          title: Text(tr('disablePageTransitions')),
+          value: sp.disablePageTransitions,
+          onChanged: (value) => sp.disablePageTransitions = value,
+        ),
+        SwitchListTile(
+          title: Text(tr('reversePageTransitions')),
+          value: sp.reversePageTransitions,
+          onChanged: sp.disablePageTransitions
+              ? null
+              : (value) => sp.reversePageTransitions = value,
+        ),
+        SwitchListTile(
+          title: Text(tr('highlightTouchTargets')),
+          value: sp.highlightTouchTargets,
+          onChanged: (value) => sp.highlightTouchTargets = value,
+        ),
+      ],
+    );
+  }
+}
+
+class _LocaleMenu extends StatelessWidget {
+  const _LocaleMenu({required this.sp});
+
+  final SettingsProvider sp;
+
+  @override
+  Widget build(BuildContext context) {
+    return appDropdownField<String>(
+      key: ValueKey(sp.forcedLocale?.toLanguageTag() ?? '_system'),
+      context: context,
+      value: sp.forcedLocale?.toLanguageTag() ?? '_system',
+      labelText: tr('language'),
+      menuWidth: appDropdownMenuWidth(
+        context,
+        [
+          tr('followSystem'),
+          ...supportedLocales.map(
+            (MapEntry<Locale, String> localeEntry) => localeEntry.value,
+          ),
+        ],
+        style: Theme.of(context).textTheme.bodyLarge,
+        horizontalPadding: 96,
+        minWidth: 150,
+      ),
+      items: [
+        DropdownMenuItem<String>(
+          value: '_system',
+          child: Text(tr('followSystem')),
+        ),
+        ...supportedLocales.map(
+          (MapEntry<Locale, String> localeEntry) => DropdownMenuItem<String>(
+            value: localeEntry.key.toLanguageTag(),
+            child: Text(localeEntry.value),
+          ),
+        ),
+      ],
+      onChanged: (String? value) {
+        final Locale? selectedLocale = value == null || value == '_system'
+            ? null
+            : supportedLocales
+                .firstWhere(
+                  (MapEntry<Locale, String> localeEntry) =>
+                      localeEntry.key.toLanguageTag() == value,
+                )
+                .key;
+        sp.forcedLocale = selectedLocale;
+        if (selectedLocale != null) {
+          context.setLocale(selectedLocale);
+        } else {
+          sp.resetLocaleSafe(context);
+        }
+      },
+    );
+  }
+}
+
+class _UiScaleSlider extends StatefulWidget {
+  const _UiScaleSlider({required this.sp});
+
+  final SettingsProvider sp;
+
+  @override
+  State<_UiScaleSlider> createState() => _UiScaleSliderState();
+}
+
+class _UiScaleSliderState extends State<_UiScaleSlider> {
+  late double _localVal;
+  bool _initializing = true;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_initializing) {
+      _localVal = widget.sp.appUiScale;
+      _initializing = false;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme cs = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 8, 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Icon(Icons.format_size_rounded, color: cs.onSurfaceVariant),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: Row(
+                    children: [
+                      Expanded(child: Text(tr('uiScale'))),
+                      Text('${(_localVal * 100).round()}%'),
+                    ],
+                  ),
+                ),
+                SliderTheme(
+                  data: SliderTheme.of(context).copyWith(
+                    trackHeight: 16,
+                    trackShape: const _GappedTrackShape(),
+                    thumbShape: const _VerticalBarThumbShape(),
+                    tickMarkShape: const RoundSliderTickMarkShape(tickMarkRadius: 3),
+                    activeTickMarkColor: cs.onPrimary,
+                    inactiveTickMarkColor: cs.primary,
+                    overlayShape: const RoundSliderOverlayShape(overlayRadius: 20),
+                  ),
+                  child: Slider(
+                    min: SettingsProvider.appUiScaleMin,
+                    max: SettingsProvider.appUiScaleMax,
+                    divisions: ((SettingsProvider.appUiScaleMax -
+                                SettingsProvider.appUiScaleMin) /
+                            0.05)
+                        .round(),
+                    label: '${(_localVal * 100).round()}%',
+                    value: _localVal,
+                    onChanged: (double value) {
+                      setState(() => _localVal = value);
+                    },
+                    onChangeEnd: (double value) {
+                      widget.sp.appUiScale = value;
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CardCornerScaleSlider extends StatefulWidget {
+  const _CardCornerScaleSlider({required this.sp});
+
+  final SettingsProvider sp;
+
+  @override
+  State<_CardCornerScaleSlider> createState() => _CardCornerScaleSliderState();
+}
+
+class _CardCornerScaleSliderState extends State<_CardCornerScaleSlider> {
+  late double _localVal;
+  bool _initializing = true;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_initializing) {
+      _localVal = widget.sp.cardCornerScale;
+      _initializing = false;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme cs = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 8, 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Icon(Icons.rounded_corner_rounded, color: cs.onSurfaceVariant),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: Row(
+                    children: [
+                      Expanded(child: Text(tr('cardCorners'))),
+                      Text('${(_localVal * 100).round()}%'),
+                    ],
+                  ),
+                ),
+                SliderTheme(
+                  data: SliderTheme.of(context).copyWith(
+                    trackHeight: 16,
+                    trackShape: const _GappedTrackShape(),
+                    thumbShape: const _VerticalBarThumbShape(),
+                    tickMarkShape: const RoundSliderTickMarkShape(tickMarkRadius: 3),
+                    activeTickMarkColor: cs.onPrimary,
+                    inactiveTickMarkColor: cs.primary,
+                    overlayShape: const RoundSliderOverlayShape(overlayRadius: 20),
+                  ),
+                  child: Slider(
+                    min: SettingsProvider.cardCornerScaleMin,
+                    max: SettingsProvider.cardCornerScaleMax,
+                    divisions: ((SettingsProvider.cardCornerScaleMax -
+                                SettingsProvider.cardCornerScaleMin) /
+                            0.10)
+                        .round(),
+                    label: '${(_localVal * 100).round()}%',
+                    value: _localVal,
+                    onChanged: (double value) {
+                      setState(() => _localVal = value);
+                    },
+                    onChangeEnd: (double value) {
+                      widget.sp.cardCornerScale = value;
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Gestures section — swipe action dropdowns.
+class _GesturesSection extends StatelessWidget {
+  const _GesturesSection();
+
+  static int _gesturesSettingsHash(SettingsProvider sp) => Object.hash(
+        sp.rightSwipeAction,
+        sp.leftSwipeAction,
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    context.select<SettingsProvider, int>(_gesturesSettingsHash);
+    final SettingsProvider sp = context.read<SettingsProvider>();
+    final ColorScheme cs = Theme.of(context).colorScheme;
+
+    final List<SwipeAction> actions =
+        swipeActionsSortedByLocalizedLabel();
+    final double swipeMenuWidth = appDropdownMenuWidth(
+      context,
+      actions.map((SwipeAction action) => tr('swipeAction_${action.name}')),
+      style: Theme.of(context).textTheme.bodyLarge,
+      horizontalPadding: 120,
+      minWidth: 180,
+      maxWidthInset: 80,
+    );
+
+    List<DropdownMenuItem<SwipeAction>> actionItems() {
+      return actions.map((SwipeAction action) {
+        return DropdownMenuItem<SwipeAction>(
+          value: action,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(_swipeActionIcon(action), size: 18),
+              const SizedBox(width: 12),
+              Text(tr('swipeAction_${action.name}')),
+            ],
+          ),
+        );
+      }).toList();
+    }
+
+    return m3eExpressiveSettingsCard(
+      context: context,
+      colorScheme: cs,
+      items: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              appDropdownField<SwipeAction>(
+                key: ValueKey('rightSwipeAction_${sp.rightSwipeAction}'),
+                context: context,
+                value: sp.rightSwipeAction,
+                labelText: tr('rightSwipeAction'),
+                menuWidth: swipeMenuWidth,
+                items: actionItems(),
+                onChanged: (SwipeAction? value) {
+                  if (value != null) sp.rightSwipeAction = value;
+                },
+              ),
+              const SizedBox(height: 16),
+              appDropdownField<SwipeAction>(
+                key: ValueKey('leftSwipeAction_${sp.leftSwipeAction}'),
+                context: context,
+                value: sp.leftSwipeAction,
+                labelText: tr('leftSwipeAction'),
+                menuWidth: swipeMenuWidth,
+                items: actionItems(),
+                onChanged: (SwipeAction? value) {
+                  if (value != null) sp.leftSwipeAction = value;
+                },
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Categories section — delegates to CategoryEditorSelector.
+class _CategoriesSection extends StatelessWidget {
+  const _CategoriesSection();
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme cs = Theme.of(context).colorScheme;
+    return m3eExpressiveSettingsCard(
+      context: context,
+      colorScheme: cs,
+      items: const [
+        Padding(
+          padding: EdgeInsets.all(16),
+          child: CategoryEditorSelector(
+            showLabelWhenNotEmpty: false,
+            showSelectedCheckmark: true,
+            showChangeIntentIcons: false,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _AboutSectionContent extends StatelessWidget {
+  const _AboutSectionContent({required this.colorScheme});
+
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    final SettingsProvider sp = context.read<SettingsProvider>();
     final TextTheme textTheme = Theme.of(context).textTheme;
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 20, 16, 6),
@@ -1372,9 +1472,8 @@ class _AboutSectionContent extends StatelessWidget {
             child: SizedBox(
               width: double.infinity,
               child: FilledButton.icon(
-                onPressed: () => _openAboutUrl(settingsProvider.sourceUrl),
-                onLongPress: () =>
-                    _copyAboutUrl(context, settingsProvider.sourceUrl),
+                onPressed: () => _openAboutUrl(sp.sourceUrl),
+                onLongPress: () => _copyAboutUrl(context, sp.sourceUrl),
                 icon: _GitHubMarkIcon(color: colorScheme.onPrimary),
                 label: Text(tr('aboutStarOnGithub')),
               ),
@@ -1398,10 +1497,8 @@ class _AboutSectionContent extends StatelessWidget {
                 Expanded(
                   child: FilledButton.tonalIcon(
                     style: _aboutSecondaryButtonStyle(colorScheme),
-                    onPressed: () =>
-                        _shareAboutUrl(settingsProvider.sourceUrl, 'ObtainX'),
-                    onLongPress: () =>
-                        _copyAboutUrl(context, settingsProvider.sourceUrl),
+                    onPressed: () => _shareAboutUrl(sp.sourceUrl, 'ObtainX'),
+                    onLongPress: () => _copyAboutUrl(context, sp.sourceUrl),
                     icon: const Icon(Icons.share_rounded),
                     label: Text(tr('share')),
                   ),

--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -1435,6 +1435,11 @@ class AppsProvider with ChangeNotifier {
   Map<String, AppInMemory> apps = {};
   final Map<String, String> appPageErrors = {};
   bool loadingApps = false;
+  // Incremented inside checkUpdates() as each app finishes its check.
+  // O(1) access so _RefreshProgressBar can avoid iterating the full app
+  // list on every 250 ms progress tick. Reset to 0 at the start of each
+  // checkUpdates and loadApps run.
+  int progressCheckedCount = 0;
   Completer<void>? _loadingCompleter;
   bool gettingUpdates = false;
   LogsProvider logs = LogsProvider();
@@ -3458,6 +3463,7 @@ class AppsProvider with ChangeNotifier {
     _loadingCompleter = Completer<void>();
     if (!silent) {
       loadingApps = true;
+      progressCheckedCount = 0;
       notifyListeners();
     }
     await _purgeStalePendingRemovalFilesWithoutLiveDeferral();
@@ -4467,6 +4473,7 @@ class AppsProvider with ChangeNotifier {
     MultiAppMultiError errors = MultiAppMultiError();
     if (!gettingUpdates) {
       gettingUpdates = true;
+      progressCheckedCount = 0;
       try {
         late List<String> appIds;
         if (specificIds != null) {
@@ -4527,12 +4534,6 @@ class AppsProvider with ChangeNotifier {
                 autoExportAfterSave: false,
               );
               appSaveCompleted = true;
-              final now = DateTime.now();
-              if (now.difference(lastProgressNotificationAt) >=
-                  progressNotificationInterval) {
-                lastProgressNotificationAt = now;
-                notifyListeners();
-              }
             } catch (error) {
               if ((error is RateLimitError || error is SocketException) &&
                   throwErrorsForRetry) {
@@ -4543,6 +4544,15 @@ class AppsProvider with ChangeNotifier {
               } else {
                 errors.add(appId, error, appName: apps[appId]?.name);
               }
+            }
+            // Increment AFTER try/catch so failed checks also contribute
+            // to progress — otherwise the bar would stall on an all-fail run.
+            progressCheckedCount += 1;
+            final now = DateTime.now();
+            if (now.difference(lastProgressNotificationAt) >=
+                progressNotificationInterval) {
+              lastProgressNotificationAt = now;
+              notifyListeners();
             }
             if (newApp != null) {
               updates.add(newApp);

--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -1017,9 +1017,9 @@ Future<String?> checkETagHeader(
       .toString();
 }
 
-void deleteFile(File file) {
+Future<void> deleteFile(File file) async {
   try {
-    file.deleteSync(recursive: true);
+    await file.delete(recursive: true);
   } on PathAccessException catch (e) {
     throw ObtainiumError(
       tr('fileDeletionError', args: [e.path ?? tr('unknown')]),
@@ -1170,8 +1170,8 @@ Future<File> _downloadFile(
   // decide whether you can use it (either return full or resume partial)
   var fullContentLength = headersResponse.contentLength;
   onContentLength?.call(fullContentLength);
-  if (useExisting && downloadedFile.existsSync()) {
-    var length = downloadedFile.lengthSync();
+  if (useExisting && await downloadedFile.exists()) {
+    var length = await downloadedFile.length();
     if (fullContentLength == null || !rangeFeatureEnabled) {
       // If there is no content length reported, assume it the existing file is fully downloaded
       // Also if the range feature is not supported, don't trust the content length if any (#1542)
@@ -1191,7 +1191,7 @@ Future<File> _downloadFile(
   File tempDownloadedFile = File('${downloadedFile.path}.part');
 
   // If there is already a temp file, a download may already be in progress - account for this (see #2073)
-  bool tempFileExists = tempDownloadedFile.existsSync();
+  bool tempFileExists = await tempDownloadedFile.exists();
   if (tempFileExists && useExisting) {
     logs?.add(
       'Partial download exists - will wait: ${tempDownloadedFile.uri.pathSegments.last}',
@@ -1203,7 +1203,7 @@ Future<File> _downloadFile(
       cancelToken?.throwIfCancelled();
       await Future.delayed(const Duration(seconds: 7));
       cancelToken?.throwIfCancelled();
-      if (tempDownloadedFile.existsSync()) {
+      if (await tempDownloadedFile.exists()) {
         int newTempFileSize = await tempDownloadedFile.length();
         if (newTempFileSize > currentTempFileSize) {
           currentTempFileSize = newTempFileSize;
@@ -1217,7 +1217,7 @@ Future<File> _downloadFile(
           break;
         }
       } else {
-        shouldReturn = downloadedFile.existsSync();
+        shouldReturn = await downloadedFile.exists();
       }
     }
     if (shouldReturn) {
@@ -1235,8 +1235,8 @@ Future<File> _downloadFile(
   // If the range feature is not available (or you need to start a ranged req from 0),
   // complete the already-started request, else cancel it and start a ranged request,
   // and open the file for writing in the appropriate mode
-  var targetFileLength = useExisting && tempDownloadedFile.existsSync()
-      ? tempDownloadedFile.lengthSync()
+  var targetFileLength = useExisting && await tempDownloadedFile.exists()
+      ? await tempDownloadedFile.length()
       : null;
   int rangeStart = targetFileLength ?? 0;
   IOSink? sink;
@@ -1245,8 +1245,8 @@ Future<File> _downloadFile(
   if (rangeFeatureEnabled && fullContentLength != null && rangeStart > 0) {
     reqHeaders.addAll({'range': 'bytes=$rangeStart-${fullContentLength - 1}'});
     sink = tempDownloadedFile.openWrite(mode: FileMode.writeOnlyAppend);
-  } else if (tempDownloadedFile.existsSync()) {
-    deleteFile(tempDownloadedFile);
+  } else if (await tempDownloadedFile.exists()) {
+    await deleteFile(tempDownloadedFile);
   }
   var responseWithClient = await sourceRequestStreamResponse(
     'GET',
@@ -1309,8 +1309,8 @@ Future<File> _downloadFile(
   } catch (_) {
     responseClient.close(force: true);
     if (cancelToken?.isCancelled == true) {
-      if (tempDownloadedFile.existsSync()) {
-        deleteFile(tempDownloadedFile);
+      if (await tempDownloadedFile.exists()) {
+        await deleteFile(tempDownloadedFile);
       }
       throw DownloadCancelledError();
     }
@@ -1324,11 +1324,11 @@ Future<File> _downloadFile(
     onProgress(progress);
   }
   if (response.statusCode < 200 || response.statusCode > 299) {
-    deleteFile(tempDownloadedFile);
+    await deleteFile(tempDownloadedFile);
     throw response.reasonPhrase;
   }
-  if (tempDownloadedFile.existsSync()) {
-    tempDownloadedFile.renameSync(downloadedFile.path);
+  if (await tempDownloadedFile.exists()) {
+    await tempDownloadedFile.rename(downloadedFile.path);
   }
   responseClient.close();
   return downloadedFile;
@@ -1705,7 +1705,7 @@ class AppsProvider with ChangeNotifier {
       app.allowIdChange = false;
       var originalAppId = app.id;
       app.id = newInfo.packageName!;
-      downloadedFile = downloadedFile.renameSync(
+      downloadedFile = await downloadedFile.rename(
         '${downloadedFile.parent.path}/${app.id}-${downloadUrl.hashCode}.${downloadedFile.path.split('.').last}',
       );
       if (apps[originalAppId] != null) {
@@ -1920,7 +1920,7 @@ class AppsProvider with ChangeNotifier {
         String apkDirPath = '${downloadedFile.path}-dir';
         await unzipFile(downloadedFile.path, '${downloadedFile.path}-dir');
         extractedDir = Directory(apkDirPath);
-        var apks = extractedDir.listSync().where((e) => isApk(e.path)).toList();
+        var apks = (await extractedDir.list().toList()).where((e) => isApk(e.path)).toList();
 
         FileSystemEntity? temp;
         apks.removeWhere((element) {
@@ -1976,12 +1976,12 @@ class AppsProvider with ChangeNotifier {
         downloadUrl,
       );
       // Delete older versions of the file if any
-      for (var file in downloadedFile.parent.listSync()) {
+      for (var file in await downloadedFile.parent.list().toList()) {
         var fn = file.path.split('/').last;
         if (fn.startsWith('${app.id}-') &&
-            FileSystemEntity.isFileSync(file.path) &&
+            await FileSystemEntity.isFile(file.path) &&
             file.path != downloadedFile.path) {
-          file.delete(recursive: true);
+          await file.delete(recursive: true);
         }
       }
       if (isAPK) {
@@ -2112,10 +2112,12 @@ class AppsProvider with ChangeNotifier {
       (await getInstalledInfo('com.berdik.letmedowngrade')) != null;
 
   Future<void> unzipFile(String filePath, String destinationPath) async {
-    await ZipFile.extractToDirectory(
-      zipFile: File(filePath),
-      destinationDir: Directory(destinationPath),
-    );
+    await Isolate.run<void>(() async {
+      await ZipFile.extractToDirectory(
+        zipFile: File(filePath),
+        destinationDir: Directory(destinationPath),
+      );
+    }, debugName: 'apk-unzip');
   }
 
   Uri? _documentUriFromSafPluginResult(dynamic pluginResult) {
@@ -2201,11 +2203,11 @@ class AppsProvider with ChangeNotifier {
         );
         if (reproducibleBuildEnforcementBlocksInstall(app, source)) {
           try {
-            if (dir.file.existsSync()) {
-              dir.file.deleteSync();
+            if (await dir.file.exists()) {
+              await dir.file.delete();
             }
-            if (dir.extracted.existsSync()) {
-              dir.extracted.deleteSync(recursive: true);
+            if (await dir.extracted.exists()) {
+              await dir.extracted.delete(recursive: true);
             }
           } catch (_) {}
           throw ObtainiumError(reproducibleBuildEnforcedBlockedMessage());
@@ -2238,12 +2240,12 @@ class AppsProvider with ChangeNotifier {
           if (enforceAttest &&
               attestationStatus != githubAttestationStatusVerified) {
             try {
-              if (dir.file.existsSync()) {
-                dir.file.deleteSync();
-              }
-              if (dir.extracted.existsSync()) {
-                dir.extracted.deleteSync(recursive: true);
-              }
+              if (await dir.file.exists()) {
+              await dir.file.delete();
+            }
+              if (await dir.extracted.exists()) {
+              await dir.extracted.delete(recursive: true);
+            }
             } catch (_) {}
             throw ObtainiumError(
               tr(
@@ -2258,8 +2260,7 @@ class AppsProvider with ChangeNotifier {
       MultiAppMultiError errors = MultiAppMultiError();
       List<File> apkFiles = [];
       for (var file
-          in dir.extracted
-              .listSync(recursive: true, followLinks: false)
+          in (await dir.extracted.list(recursive: true, followLinks: false).toList())
               .whereType<File>()) {
         if (isApk(file.path)) {
           apkFiles.add(file);
@@ -2296,7 +2297,7 @@ class AppsProvider with ChangeNotifier {
           skipApkSaveFolderPersistForPrimaryApk: true,
           thirdPartyHandoffContainerPath:
               settingsProvider.installerMode == 'legacy' &&
-                  dir.file.existsSync()
+                  await dir.file.exists()
               ? dir.file.path
               : null,
         );
@@ -2330,7 +2331,7 @@ class AppsProvider with ChangeNotifier {
           saveApkCopies &&
           appForSave != null &&
           resolvedApkSaveUri != null &&
-          dir.file.existsSync()) {
+          await dir.file.exists()) {
         try {
           bundleCopiedOk = await _chunkedCopyApkToSafTree(
             dir.file,
@@ -2348,7 +2349,7 @@ class AppsProvider with ChangeNotifier {
           appForSave != null && isSkipActiveForCurrentLatest(appForSave);
       final bool hasSaveFolder = saveApkCopies && resolvedApkSaveUri != null;
       final bool shouldDeleteBundle;
-      if (hasSaveFolder && appForSave != null && dir.file.existsSync()) {
+      if (hasSaveFolder && appForSave != null && await dir.file.exists()) {
         shouldDeleteBundle =
             bundleCopiedOk && (somethingInstalled || skipLatest);
       } else if (!saveApkCopies) {
@@ -2367,12 +2368,12 @@ class AppsProvider with ChangeNotifier {
         shouldDeleteBundle =
             somethingInstalled || (!somethingInstalled && skipLatest);
       }
-      if (shouldDeleteBundle && dir.file.existsSync()) {
+      if (shouldDeleteBundle && await dir.file.exists()) {
         try {
-          dir.file.deleteSync();
+          await dir.file.delete();
         } catch (_) {}
       }
-      dir.extracted.delete(recursive: true);
+      unawaited(dir.extracted.delete(recursive: true));
     } catch (exception, stackTrace) {
       logs.add(
         'Post-install bundle disposition failed: ${exception.toString()}\n$stackTrace',
@@ -2413,12 +2414,12 @@ class AppsProvider with ChangeNotifier {
         );
         if (reproducibleBuildEnforcementBlocksInstall(app, source)) {
           try {
-            if (file.file.existsSync()) {
-              file.file.deleteSync();
+            if (await file.file.exists()) {
+              await file.file.delete();
             }
             for (var additionalApk in additionalAPKs) {
-              if (additionalApk.file.existsSync()) {
-                additionalApk.file.deleteSync();
+              if (await additionalApk.file.exists()) {
+                await additionalApk.file.delete();
               }
             }
           } catch (_) {}
@@ -2452,13 +2453,13 @@ class AppsProvider with ChangeNotifier {
           if (enforceAttest &&
               attestationStatus != githubAttestationStatusVerified) {
             try {
-              if (file.file.existsSync()) {
-                file.file.deleteSync();
-              }
+              if (await file.file.exists()) {
+              await file.file.delete();
+            }
               for (var a in additionalAPKs) {
-                if (a.file.existsSync()) {
-                  a.file.deleteSync();
-                }
+                if (await a.file.exists()) {
+              await a.file.delete();
+            }
               }
             } catch (_) {}
             throw ObtainiumError(
@@ -2474,8 +2475,11 @@ class AppsProvider with ChangeNotifier {
       if (firstTimeWithContext != null &&
           settingsProvider.beforeNewInstallsShareToAppVerifier &&
           (await getInstalledInfo('dev.soupslurpr.appverifier')) != null) {
+        final Uint8List apkBytes = await Isolate.run<Uint8List>(() async {
+          return await file.file.readAsBytes();
+        }, debugName: 'apk-read-bytes');
         XFile f = XFile.fromData(
-          file.file.readAsBytesSync(),
+          apkBytes,
           mimeType: 'application/vnd.android.package-archive',
         );
         Fluttertoast.showToast(
@@ -2489,9 +2493,9 @@ class AppsProvider with ChangeNotifier {
       );
       if (newInfo == null) {
         try {
-          deleteFile(file.file);
+          await deleteFile(file.file);
           for (var a in additionalAPKs) {
-            deleteFile(a.file);
+            await deleteFile(a.file);
           }
         } catch (e) {
           //
@@ -2530,7 +2534,7 @@ class AppsProvider with ChangeNotifier {
         }
         final String thirdPartyPathsArg;
         if (thirdPartyHandoffContainerPath != null &&
-            File(thirdPartyHandoffContainerPath).existsSync()) {
+            await File(thirdPartyHandoffContainerPath).exists()) {
           thirdPartyPathsArg = thirdPartyHandoffContainerPath;
         } else {
           thirdPartyPathsArg = [
@@ -2611,7 +2615,7 @@ class AppsProvider with ChangeNotifier {
       final bool hasSaveFolder = apkSaveTreeUri != null;
 
       var copiedOk = false;
-      if (hasSaveFolder && appRef != null && primaryFile.existsSync()) {
+      if (hasSaveFolder && appRef != null && await primaryFile.exists()) {
         try {
           copiedOk = await _chunkedCopyApkToSafTree(
             primaryFile,
@@ -2635,16 +2639,16 @@ class AppsProvider with ChangeNotifier {
         deletePrimary = !installReportedOk && skipLatest;
       }
 
-      if (deletePrimary && primaryFile.existsSync()) {
+      if (deletePrimary && await primaryFile.exists()) {
         try {
-          primaryFile.deleteSync();
+          await primaryFile.delete();
         } catch (_) {}
       }
       if (deletePrimary) {
         for (final suppliedApk in additionalAPKs) {
           try {
-            if (suppliedApk.file.existsSync()) {
-              suppliedApk.file.deleteSync();
+            if (await suppliedApk.file.exists()) {
+              await suppliedApk.file.delete();
             }
           } catch (_) {}
         }
@@ -2669,7 +2673,7 @@ class AppsProvider with ChangeNotifier {
     }
 
     String obbDirPath = "${await getStorageRootPath()}/Android/obb/$appId";
-    Directory(obbDirPath).createSync(recursive: true);
+    await Directory(obbDirPath).create(recursive: true);
 
     String obbFileName = file.path.split("/").last;
     await file.copy("$obbDirPath/$obbFileName");
@@ -3227,8 +3231,8 @@ class AppsProvider with ChangeNotifier {
     Directory appsDir = Directory(
       '${(await getAppStorageDir()).path}/app_data',
     );
-    if (!appsDir.existsSync()) {
-      appsDir.createSync();
+    if (!await appsDir.exists()) {
+      await appsDir.create();
     }
     return appsDir;
   }
@@ -3686,7 +3690,7 @@ class AppsProvider with ChangeNotifier {
     if (appId == null || apps[appId] == null) return;
 
     final File userIconFile = _userAppIconPngFile(appId);
-    if (userIconFile.existsSync()) {
+    if (await userIconFile.exists()) {
       try {
         final Uint8List iconBytes = await userIconFile.readAsBytes();
         if (_bytesLookLikePng(iconBytes)) {
@@ -3716,10 +3720,10 @@ class AppsProvider with ChangeNotifier {
     if (apps[appId]!.icon != null && !ignoreCache) return;
 
     var cachedIcon = File('${iconsCacheDir.path}/$appId.png');
-    if (ignoreCache && cachedIcon.existsSync()) {
+    if (ignoreCache && await cachedIcon.exists()) {
       await cachedIcon.delete();
     }
-    var alreadyCached = cachedIcon.existsSync() && !ignoreCache;
+    var alreadyCached = await cachedIcon.exists() && !ignoreCache;
     Uint8List? icon = alreadyCached
         ? await cachedIcon.readAsBytes()
         : await apps[appId]!.installedInfo?.applicationInfo?.getAppIcon();
@@ -3782,7 +3786,7 @@ class AppsProvider with ChangeNotifier {
   Future<Uint8List?> loadIconPreviewExcludingUserOverride(String appId) async {
     if (apps[appId] == null) return null;
     final File cachedIcon = File('${iconsCacheDir.path}/$appId.png');
-    if (cachedIcon.existsSync()) {
+    if (await cachedIcon.exists()) {
       try {
         return await cachedIcon.readAsBytes();
       } catch (e) {
@@ -3840,7 +3844,7 @@ class AppsProvider with ChangeNotifier {
   ) async {
     try {
       final File sourceFile = File(filePath);
-      if (!sourceFile.existsSync()) {
+      if (!await sourceFile.exists()) {
         return tr('unexpectedError');
       }
       final Uint8List bytes = await sourceFile.readAsBytes();
@@ -3854,8 +3858,8 @@ class AppsProvider with ChangeNotifier {
   Future<void> resetAppIconToDefault(String appId) async {
     if (apps[appId] == null) return;
     final File userFile = _userAppIconPngFile(appId);
-    if (userFile.existsSync()) {
-      deleteFile(userFile);
+    if (await userFile.exists()) {
+      await deleteFile(userFile);
     }
     await updateAppIcon(appId, ignoreCache: true);
   }
@@ -3900,6 +3904,27 @@ class AppsProvider with ChangeNotifier {
         notifyListeners();
       }
     }
+
+    // Batch pre-fetch: one `getInstalledPackages` call instead of N ×
+    // `getInstalledInfo` calls (each of which internally re-lists packages).
+    // For bulk saves (e.g. after a scan of 100+ apps) this eliminates
+    // hundreds of redundant platform-channel round-trips.
+    final Map<String, PackageInfo> installedByPackage;
+    final Map<String, String> labelsByPackage;
+    if (updateInstalledInfo && apps.isNotEmpty) {
+      final List<PackageInfo> allInstalled =
+          await getAllInstalledInfo(light: true);
+      installedByPackage = <String, PackageInfo>{
+        for (final pkg in allInstalled)
+          if (pkg.packageName != null) pkg.packageName!: pkg,
+      };
+      final List<String> appIds = apps.map((a) => a.id).toList();
+      labelsByPackage = await BulkImportService.getApplicationLabels(appIds);
+    } else {
+      installedByPackage = <String, PackageInfo>{};
+      labelsByPackage = <String, String>{};
+    }
+
     await Future.wait(
       apps.map((appToSave) async {
         var app = appToSave.deepCopy();
@@ -3917,6 +3942,33 @@ class AppsProvider with ChangeNotifier {
                   app.name.trim() == app.id ||
                   app.name.trim() == cachedName)) {
             app.name = cachedInMemory.app.name;
+          }
+        } else if (updateInstalledInfo && apps.isNotEmpty) {
+          // Use the pre-fetched batch data instead of per-app platform calls.
+          info = installedByPackage[app.id];
+          final bool installedUnchanged =
+              cachedInMemory != null &&
+                  cachedInMemory.installedInfo?.packageName == info?.packageName &&
+                  cachedInMemory.installedInfo?.versionName == info?.versionName &&
+                  cachedInMemory.installedInfo?.versionCode == info?.versionCode;
+          if (installedUnchanged) {
+            icon = cachedInMemory.icon;
+          } else {
+            icon = await info?.applicationInfo?.getAppIcon();
+            final String? localizedLabel = labelsByPackage[app.id]?.trim();
+            if (Platform.isAndroid && info != null) {
+              if (localizedLabel?.isNotEmpty != true) {
+                // Fallback: single app-specific call only when the batch
+                // lookup didn't produce a label (rare path).
+                info = await getInstalledInfo(app.id);
+              }
+            }
+            final String? appLabel = localizedLabel?.isNotEmpty == true
+                ? localizedLabel
+                : info?.applicationInfo?.nonLocalizedLabel?.toString().trim();
+            if (appLabel?.isNotEmpty == true) {
+              app.name = appLabel!;
+            }
           }
         } else {
           info = await getInstalledInfo(app.id);
@@ -3997,34 +4049,34 @@ class AppsProvider with ChangeNotifier {
     List<String> appIds, {
     bool deleteMainJson = true,
   }) async {
-    final List<FileSystemEntity> apkFiles = apkDir.listSync();
+    final List<FileSystemEntity> apkFiles = await apkDir.list().toList();
     final Directory appsDirectory = await getAppsDir();
     await Future.wait(
       appIds.map((String appId) async {
         if (deleteMainJson) {
           final File mainJson = File('${appsDirectory.path}/$appId.json');
-          if (mainJson.existsSync()) {
-            deleteFile(mainJson);
+          if (await mainJson.exists()) {
+            await deleteFile(mainJson);
           }
         }
         for (final FileSystemEntity element in apkFiles) {
           if (_fileBasename(element.path).startsWith('$appId-')) {
-            element.deleteSync(recursive: true);
+            await element.delete(recursive: true);
           }
         }
         final File standardIconCache = File('${iconsCacheDir.path}/$appId.png');
-        if (standardIconCache.existsSync()) {
-          deleteFile(standardIconCache);
+        if (await standardIconCache.exists()) {
+          await deleteFile(standardIconCache);
         }
         final File userIconStored = _userAppIconPngFile(appId);
-        if (userIconStored.existsSync()) {
-          deleteFile(userIconStored);
+        if (await userIconStored.exists()) {
+          await deleteFile(userIconStored);
         }
         final File legacyUserIconInCache = File(
           '${iconsCacheDir.path}/$appId.user.png',
         );
-        if (legacyUserIconInCache.existsSync()) {
-          deleteFile(legacyUserIconInCache);
+        if (await legacyUserIconInCache.exists()) {
+          await deleteFile(legacyUserIconInCache);
         }
       }),
     );
@@ -4047,18 +4099,18 @@ class AppsProvider with ChangeNotifier {
     final Directory pendingDir = Directory(
       '${appsDirectory.path}/pending_removal',
     );
-    if (!pendingDir.existsSync()) {
-      pendingDir.createSync(recursive: true);
+    if (!await pendingDir.exists()) {
+      await pendingDir.create(recursive: true);
     }
     final File sourceJson = File('${appsDirectory.path}/$appId.json');
-    if (!sourceJson.existsSync()) {
+    if (!await sourceJson.exists()) {
       return;
     }
     final File destinationJson = File('${pendingDir.path}/$appId.json');
-    if (destinationJson.existsSync()) {
-      deleteFile(destinationJson);
+    if (await destinationJson.exists()) {
+      await deleteFile(destinationJson);
     }
-    sourceJson.renameSync(destinationJson.path);
+    await sourceJson.rename(destinationJson.path);
   }
 
   Future<void> _restoreAppJsonFromPendingRemoval(String appId) async {
@@ -4067,14 +4119,14 @@ class AppsProvider with ChangeNotifier {
       '${appsDirectory.path}/pending_removal/$appId.json',
     );
     final File mainJson = File('${appsDirectory.path}/$appId.json');
-    if (!pendingJson.existsSync()) {
+    if (!await pendingJson.exists()) {
       return;
     }
-    if (mainJson.existsSync()) {
-      deleteFile(pendingJson);
+    if (await mainJson.exists()) {
+      await deleteFile(pendingJson);
       return;
     }
-    pendingJson.renameSync(mainJson.path);
+    await pendingJson.rename(mainJson.path);
   }
 
   /// Drops pending-removal JSON that no longer has an in-memory deferral (e.g. after process restart).
@@ -4083,10 +4135,10 @@ class AppsProvider with ChangeNotifier {
     final Directory pendingDir = Directory(
       '${appsDirectory.path}/pending_removal',
     );
-    if (!pendingDir.existsSync()) {
+    if (!await pendingDir.exists()) {
       return;
     }
-    for (final FileSystemEntity entity in pendingDir.listSync()) {
+    await for (final FileSystemEntity entity in pendingDir.list()) {
       if (entity is! File) continue;
       if (!entity.path.toLowerCase().endsWith('.json')) continue;
       final String fileName = _fileBasename(entity.path);
@@ -4094,7 +4146,7 @@ class AppsProvider with ChangeNotifier {
       if (_deferredObtainiumSnapshots.containsKey(appId)) {
         continue;
       }
-      deleteFile(entity);
+      await deleteFile(entity);
       await deleteObtainiumAppDiskData([appId], deleteMainJson: false);
     }
   }
@@ -4125,7 +4177,7 @@ class AppsProvider with ChangeNotifier {
       if (snapshot == null) continue;
       await _restoreAppJsonFromPendingRemoval(appId);
       final File mainJson = File('${(await getAppsDir()).path}/$appId.json');
-      if (!mainJson.existsSync()) {
+      if (!await mainJson.exists()) {
         await saveApps(
           [snapshot.app],
           onlyIfExists: false,
@@ -4144,20 +4196,20 @@ class AppsProvider with ChangeNotifier {
     _deferredObtainiumSnapshots.remove(appId);
     final Directory appsDirectory = await getAppsDir();
     final File mainJson = File('${appsDirectory.path}/$appId.json');
-    if (mainJson.existsSync()) {
+    if (await mainJson.exists()) {
       final File stalePending = File(
         '${appsDirectory.path}/pending_removal/$appId.json',
       );
-      if (stalePending.existsSync()) {
-        deleteFile(stalePending);
+      if (await stalePending.exists()) {
+        await deleteFile(stalePending);
       }
       return;
     }
     final File pendingJson = File(
       '${appsDirectory.path}/pending_removal/$appId.json',
     );
-    if (pendingJson.existsSync()) {
-      deleteFile(pendingJson);
+    if (await pendingJson.exists()) {
+      await deleteFile(pendingJson);
     }
     await deleteObtainiumAppDiskData([appId], deleteMainJson: false);
     export(isAuto: true);

--- a/lib/services/bulk_scan_cache.dart
+++ b/lib/services/bulk_scan_cache.dart
@@ -50,8 +50,8 @@ class BulkScanCache {
         await getExternalStorageDirectory() ??
         await getApplicationDocumentsDirectory();
     final Directory dir = Directory('${base.path}/$_relativeDir');
-    if (!dir.existsSync()) {
-      dir.createSync(recursive: true);
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
     }
     return dir;
   }
@@ -68,7 +68,7 @@ class BulkScanCache {
     }
     try {
       final File file = await _file();
-      if (!file.existsSync()) {
+      if (!await file.exists()) {
         _cache = {};
         return {};
       }
@@ -162,9 +162,9 @@ class BulkScanCache {
         disk.clear();
       });
       // Also remove the (now-empty) file so a subsequent load short-circuits
-      // on `existsSync == false`.
+      // on `exists == false`.
       final File file = await _file();
-      if (file.existsSync()) {
+      if (await file.exists()) {
         await file.delete();
       }
     } catch (_) {


### PR DESCRIPTION

### 1. GitHub Proxy & Download Optimization

**1.  — Add GHReqPrefix proxy support for asset downloads**  
Introduced the `GHReqPrefix` config field, allowing users to configure a custom proxy prefix (e.g., CDN, mirror site) for GitHub asset downloads. Modified `assetUrlPrefetchModifier` to dynamically inject the proxy prefix before downloads.

**2.  — Fix: GitHub use browser_download_url**  
Changed the GitHub APK download URL retrieval to use `browser_download_url` instead of the default URL, fixing an issue where some release assets could not be properly linked.

**3.  — Read GHReqPrefix from sourceConfig instead of additionalSettings**  
Moved `GHReqPrefix` reading from `additionalSettings` to `sourceConfig`, aligning proxy configuration with other source-level settings, and fixing cases where the configuration was not being applied.

**4.  — Prevent double proxy prefix in asset URL when already proxied**  
Fixed a bug in `assetUrlPrefetchModifier` where the proxy prefix was being concatenated twice (producing malformed URLs like `https://proxy.example.com/https://proxy.example.com/...`). The code now detects whether the URL already contains the proxy prefix before adding one.

**5.  — Comment out clearing GitHub token when GHReqPrefix is set**  
Previously, setting `GHReqPrefix` forcibly cleared `creds` (GitHub token), which blocked access to private repositories when the proxy was enabled. This logic is now commented out, allowing tokens and proxy to work together.

### 2. Translation & Text Fixes 

**6.  — Use downloadingX translation key for download progress label**  
Changed the download progress label text in `lib/pages/app.dart` to use the `downloadingX` translation key, aligning it with other download-related UI strings so it's properly handled by the i18n system.

### 3. Performance Optimization

**7.  — Eliminate sync file I/O blocking, batch-prefetch installed app info**  
- Converted all sync file operations (`existsSync`, `listSync`, `deleteSync`, `renameSync`, `readAsBytesSync`, `createSync`, `lengthSync`, `isFileSync`) to async variants
- Moved APK/ZIP extraction into `Isolate.run` to avoid UI jank during installation
- Batch-prefetched `getAllInstalledInfo` + `getApplicationLabels` in `saveApps()` to avoid N redundant platform-channel calls
- Made `favicon_cache` and `bulk_scan_cache` fully async
- APK share read in the install flow moved to `Isolate.run`
- Files changed: `providers/apps_provider.dart`, `favicon_cache.dart`, `services/bulk_scan_cache.dart`

**8.  — Settings page: replace context.watch with targeted context.select subscriptions**  
- Split `SettingsPage` `build()` into 6 section widgets, each subscribing only to its specific settings via `context.select` + `Object.hash`
- Updates section: 14-field subscription hash (`_updateSettingsHash`)
- Appearance section: 10-field subscription hash (`_appearanceSettingsHash`)
- Gestures section: 2-field subscription hash (`_gesturesSettingsHash`)
- Source-specific section: 1-field subscription (prefs != null)
- Converted all 3 sliders (update interval, UI scale, card corner scale) to StatefulWidgets that use local state during drag, writing back to `SettingsProvider` only on `onChangeEnd`
- Collapse state moved from `SettingsProvider.notifyListeners` to local `setState`
- `_AboutSectionContent` reads `SettingsProvider` via `context.read` instead of constructor injection
- Result: clicking a toggle or dragging a slider no longer rebuilds the entire settings page
- File changed: `pages/settings.dart` (+1158 / -1061 lines)

**9. — Optimize app list rendering performance**  
- Changed `_existingUpdatesCache` from `List` to `Set`, reducing `contains()` lookups in pinUpdates ordering and `isInUpdatesGroup` checks from O(n) to O(1)
- Replaced O(n × folders) folder count computation with a single O(n) pass, cached on `listBuildToken` to avoid recomputation across rebuilds
- Replaced O(groups × n) nested-loop grouping index building with single-pass Map accumulation for category/source/appType groups
- Eliminated the O(n²) reduce+spread-list pattern in `getListedCategories`
- Reduced `getSource()` calls from O(sources × n) to O(n) in source grouping by computing the source key once per app

**10.  — Eliminate O(n) iteration in progress bar animation**  
- Added `AppsProvider.progressCheckedCount` counter for O(1) progress reading
- `_RefreshProgressBar`'s `context.select` callback previously iterated every app on every notify (roughly every 250ms), allocating a new `folderIdsForApp` List per app
- Changed to read `(loadingApps, progressCheckedCount)`: **O(n) → O(1)**
- Wrapped `LinearProgressIndicatorM3E` in `RepaintBoundary` to isolate animation repaints from the parent tree