### PR TITLE
feat: add rippling wavy progress indicators (linear + circular)

### DIFF
--- a/lib/components/bulk_add_widget.dart
+++ b/lib/components/bulk_add_widget.dart
@@ -6,12 +6,12 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:expressive_loading_indicator/expressive_loading_indicator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show ScrollCacheExtent;
-import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 import 'package:obtainium/app_sources/apkmirror.dart';
 import 'package:obtainium/app_sources/apkpure.dart';
 import 'package:obtainium/app_sources/fdroid.dart';
 import 'package:obtainium/app_sources/github.dart';
 import 'package:obtainium/app_sources/izzyondroid.dart';
+import 'package:obtainium/components/rippling_wavy_progress/linear.dart';
 import 'package:obtainium/custom_errors.dart';
 import 'package:obtainium/providers/apps_provider.dart';
 import 'package:obtainium/providers/logs_provider.dart';
@@ -1439,7 +1439,7 @@ class BulkAddWidgetState extends State<BulkAddWidget> {
                     // M3 Expressive wavy progress bar. Owns its own height
                     // and shape per the spec, so we drop the previous
                     // ClipRRect/minHeight wrapping.
-                    LinearProgressIndicatorM3E(
+                    LinearRipplingWavyProgressIndicator(
                       value: started ? progressValue : null,
                     ),
                   ],

--- a/lib/components/rippling_wavy_progress/circular.dart
+++ b/lib/components/rippling_wavy_progress/circular.dart
@@ -20,7 +20,7 @@ class CircularRipplingWavyProgressIndicator extends StatefulWidget {
   /// Width of the painted stroke.
   final double strokeWidth;
 
-  /// Arc-length gap between the track and active arcs. Defaults to 5.0.
+  /// Arc-length gap between the edge of the track and active arcs.
   final double gapWidth;
 
   /// Radial amplitude of the wave squiggle.
@@ -28,9 +28,6 @@ class CircularRipplingWavyProgressIndicator extends StatefulWidget {
 
   /// Along‑arc wavelength in logical pixels.
   final double wavelength;
-
-  /// Number of line segments used to draw the wavy arc.
-  final int steps;
 
   const CircularRipplingWavyProgressIndicator({
     super.key,
@@ -41,10 +38,9 @@ class CircularRipplingWavyProgressIndicator extends StatefulWidget {
     this.dragDuration = const Duration(milliseconds: 500),
     this.waveSpeed = 1.0,
     this.strokeWidth = 4.0,
-    this.gapWidth = 5.0,
+    this.gapWidth = 1.0,
     this.amplitude = 1.0,
     this.wavelength = 15.0,
-    this.steps = 120,
   });
 
   @override
@@ -139,7 +135,6 @@ class _CircularRipplingWavyProgressState
                 strokeWidth: widget.strokeWidth,
                 amplitude: widget.amplitude,
                 wavelength: widget.wavelength,
-                steps: widget.steps,
                 gapWidth: widget.gapWidth,
               ),
             ),
@@ -159,7 +154,6 @@ class _CircularRipplingWavyPainter extends CustomPainter {
     required this.strokeWidth,
     required this.amplitude,
     required this.wavelength,
-    required this.steps,
     required this.gapWidth,
   });
 
@@ -170,8 +164,10 @@ class _CircularRipplingWavyPainter extends CustomPainter {
   final double strokeWidth;
   final double amplitude;
   final double wavelength;
-  final int steps;
   final double gapWidth;
+
+  bool get _isIndeterminate => value == null;
+  bool get _isClosedLoop => value == null || value! >= 1.0;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -179,31 +175,51 @@ class _CircularRipplingWavyPainter extends CustomPainter {
     final radius = (math.min(size.width, size.height) - strokeWidth) / 2;
     if (radius <= 0) return;
 
+    final circumference = 2 * math.pi * radius;
+    final steps = (circumference / 2.5).round().clamp(60, 360);
+
+    // Align the wavelength to the circumference so that the wave pattern is complete
+    // and doesn't get cut off at the end of the arc.
+    final waveCount = (circumference / wavelength).round().clamp(
+      1,
+      double.infinity,
+    );
+    final alignedWavelength = circumference / waveCount;
+
     const startAngle = -math.pi / 2;
-    final sweep = value == null
+    final sweep = _isIndeterminate
         ? 2 * math.pi
         : value!.clamp(0.0, 1.0) * 2 * math.pi;
     final endAngle = startAngle + sweep;
 
-    final gapArcLen = sweep == 0 ? 0.0 : gapWidth;
+    final gapArcLen = sweep == 0 ? 0.0 : (gapWidth + strokeWidth);
     final gapAngle = gapArcLen / radius;
     final rect = Rect.fromCircle(center: center, radius: radius);
 
     // Draw the track arc with a gap at both ends of the active arc
-    if (value != null && value! < 1.0) {
-      final trackSweep = 2 * math.pi - sweep - 2 * gapAngle;
-      if (trackSweep > 0) {
-        canvas.drawArc(
-          rect,
-          endAngle + gapAngle,
-          trackSweep,
-          false,
-          Paint()
-            ..color = track
-            ..style = PaintingStyle.stroke
-            ..strokeWidth = strokeWidth
-            ..strokeCap = StrokeCap.round,
-        );
+    if (!_isIndeterminate && value! < 1.0) {
+      final minGapAngle = strokeWidth / radius;
+      final requiredForGaps = 2 * minGapAngle;
+      final availableSpace = 2 * math.pi - sweep;
+      if (availableSpace > requiredForGaps) {
+        final minTrackAngle = 1 / radius;
+        // So that the track isn't cut off prematurely when the value is reaches the end.
+        final maxTrackFriendlyGap = (availableSpace - minTrackAngle) / 2;
+        final currentGapAngle = math.min(gapAngle, maxTrackFriendlyGap);
+        final trackSweep = availableSpace - 2 * currentGapAngle;
+        if (trackSweep > 0) {
+          canvas.drawArc(
+            rect,
+            endAngle + currentGapAngle,
+            trackSweep,
+            false,
+            Paint()
+              ..color = track
+              ..style = PaintingStyle.stroke
+              ..strokeWidth = strokeWidth
+              ..strokeCap = StrokeCap.round,
+          );
+        }
       }
     }
 
@@ -215,25 +231,40 @@ class _CircularRipplingWavyPainter extends CustomPainter {
       ..color = active
       ..style = PaintingStyle.stroke
       ..strokeWidth = strokeWidth
-      ..strokeCap = StrokeCap.round;
+      ..strokeJoin = StrokeJoin.round;
+
+    if (!_isClosedLoop) {
+      wavePaint.strokeCap = StrokeCap.round;
+    }
 
     final path = Path();
     for (int i = 0; i <= steps; i++) {
       final t = i / steps;
       final angle = startAngle + sweep * t;
       final arcLen = radius * (angle - startAngle);
-      final wave = math.sin(arcLen / wavelength * 2 * math.pi + phase);
+      final wave = math.sin(arcLen / alignedWavelength * 2 * math.pi + phase);
 
-      double r = radius + amplitude * wave;
+      double currentAmplitude = amplitude;
 
-      // Taper the wave amplitude to 0 at the end of the arc
-      final taperLen = wavelength / 2;
-      final arcToEnd = radius * (endAngle - angle);
-      if (arcToEnd < taperLen && arcToEnd >= 0) {
-        final taperFactor = math.sin((arcToEnd / taperLen) * math.pi / 2);
-        r = radius + (amplitude * taperFactor) * wave;
+      // Taper the wave amplitude to 0 at the start & end of the arc
+      // Only when not a closed loop, otherwise it'd look weird with
+      // a dent at the top.
+      if (!_isClosedLoop) {
+        final taperLen = alignedWavelength / 2;
+
+        if (arcLen < taperLen && arcLen >= 0) {
+          final startTaperFactor = math.sin((arcLen / taperLen) * math.pi / 2);
+          currentAmplitude *= startTaperFactor;
+        }
+
+        final arcToEnd = radius * (endAngle - angle);
+        if (arcToEnd < taperLen && arcToEnd >= 0) {
+          final endTaperFactor = math.sin((arcToEnd / taperLen) * math.pi / 2);
+          currentAmplitude *= endTaperFactor;
+        }
       }
 
+      final r = radius + currentAmplitude * wave;
       final x = center.dx + r * math.cos(angle);
       final y = center.dy + r * math.sin(angle);
       if (i == 0) {
@@ -242,6 +273,11 @@ class _CircularRipplingWavyPainter extends CustomPainter {
         path.lineTo(x, y);
       }
     }
+
+    if (_isClosedLoop) {
+      path.close();
+    }
+
     canvas.drawPath(path, wavePaint);
   }
 
@@ -254,7 +290,6 @@ class _CircularRipplingWavyPainter extends CustomPainter {
         oldDelegate.strokeWidth != strokeWidth ||
         oldDelegate.amplitude != amplitude ||
         oldDelegate.wavelength != wavelength ||
-        oldDelegate.steps != steps ||
         oldDelegate.gapWidth != gapWidth;
   }
 }

--- a/lib/components/rippling_wavy_progress/circular.dart
+++ b/lib/components/rippling_wavy_progress/circular.dart
@@ -11,7 +11,7 @@ class CircularRipplingWavyProgressIndicator extends StatefulWidget {
   final Color? activeColor;
   final Color? trackColor;
 
-  /// Smooth transition duration when [value] changes.
+  /// Smooth transition duration when [value] increases.
   final Duration dragDuration;
 
   /// Wave animation speed in cycles per second.
@@ -94,12 +94,18 @@ class _CircularRipplingWavyProgressState
         _phaseController.repeat();
       }
     }
-    if (oldWidget.value != widget.value && widget.value != null) {
-      _valueController.animateTo(
-        widget.value!,
-        duration: widget.dragDuration,
-        curve: Curves.easeOutCubic,
-      );
+
+    // Only animate when the value increases else snap
+    if (oldWidget.value != widget.value) {
+      if (widget.value == null || widget.value! <= _valueController.value) {
+        _valueController.value = widget.value ?? _valueController.lowerBound;
+      } else {
+        _valueController.animateTo(
+          widget.value!,
+          duration: widget.dragDuration,
+          curve: Curves.easeOutCubic,
+        );
+      }
     }
   }
 

--- a/lib/components/rippling_wavy_progress/circular.dart
+++ b/lib/components/rippling_wavy_progress/circular.dart
@@ -1,0 +1,254 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
+
+/// A circular progress indicator with a wavy arc that ripples
+/// along the active portion rather than rotating the ring.
+class CircularRipplingWavyProgressIndicator extends StatefulWidget {
+  final double? value;
+  final CircularProgressM3ESize size;
+  final Color? activeColor;
+  final Color? trackColor;
+
+  /// Smooth transition duration when [value] changes.
+  final Duration dragDuration;
+
+  /// Wave animation speed in cycles per second.
+  final double waveSpeed;
+
+  /// Width of the painted stroke.
+  final double strokeWidth;
+
+  /// Arc-length gap between the track and active arcs. Defaults to 5.0.
+  final double gapWidth;
+
+  /// Radial amplitude of the wave squiggle.
+  final double amplitude;
+
+  /// Along‑arc wavelength in logical pixels.
+  final double wavelength;
+
+  /// Number of line segments used to draw the wavy arc.
+  final int steps;
+
+  const CircularRipplingWavyProgressIndicator({
+    super.key,
+    this.value,
+    this.size = CircularProgressM3ESize.m,
+    this.activeColor,
+    this.trackColor,
+    this.dragDuration = const Duration(milliseconds: 500),
+    this.waveSpeed = 1.0,
+    this.strokeWidth = 4.0,
+    this.gapWidth = 5.0,
+    this.amplitude = 1.0,
+    this.wavelength = 15.0,
+    this.steps = 120,
+  });
+
+  @override
+  State<CircularRipplingWavyProgressIndicator> createState() =>
+      _CircularRipplingWavyProgressState();
+}
+
+class _CircularRipplingWavyProgressState
+    extends State<CircularRipplingWavyProgressIndicator>
+    with TickerProviderStateMixin {
+  late final AnimationController _phaseController;
+  late final AnimationController _valueController;
+  late final Listenable _mergedListeners;
+
+  Duration _getDuration(double cyclesPerSecond) {
+    return Duration(
+      milliseconds: (1000 / cyclesPerSecond.clamp(0.001, double.infinity))
+          .round(),
+    );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _phaseController = AnimationController(
+      vsync: this,
+      duration: _getDuration(widget.waveSpeed),
+      lowerBound: 1e-10,
+      upperBound: 2 * math.pi,
+    )..repeat();
+    _valueController = AnimationController(
+      vsync: this,
+      duration: widget.dragDuration,
+      value: widget.value,
+    );
+    _mergedListeners = Listenable.merge([_phaseController, _valueController]);
+  }
+
+  @override
+  void didUpdateWidget(
+    covariant CircularRipplingWavyProgressIndicator oldWidget,
+  ) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.waveSpeed != widget.waveSpeed) {
+      _phaseController.duration = _getDuration(widget.waveSpeed);
+      if (_phaseController.isAnimating) {
+        _phaseController.repeat();
+      }
+    }
+    if (oldWidget.value != widget.value && widget.value != null) {
+      _valueController.animateTo(
+        widget.value!,
+        duration: widget.dragDuration,
+        curve: Curves.easeOutCubic,
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _phaseController.dispose();
+    _valueController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _mergedListeners,
+      builder: (context, _) {
+        final cs = Theme.of(context).colorScheme;
+        final active = widget.activeColor ?? cs.primary;
+        final track =
+            widget.trackColor ?? cs.onSurfaceVariant.withValues(alpha: 0.24);
+        final value = widget.value == null ? null : _valueController.value;
+        return RepaintBoundary(
+          child: SizedBox(
+            width: widget.size.diameterWavy,
+            height: widget.size.diameterWavy,
+            child: CustomPaint(
+              painter: _CircularRipplingWavyPainter(
+                value: value,
+                active: active,
+                track: track,
+                phase: _phaseController.value,
+                strokeWidth: widget.strokeWidth,
+                amplitude: widget.amplitude,
+                wavelength: widget.wavelength,
+                steps: widget.steps,
+                gapWidth: widget.gapWidth,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _CircularRipplingWavyPainter extends CustomPainter {
+  _CircularRipplingWavyPainter({
+    this.value,
+    required this.active,
+    required this.track,
+    required this.phase,
+    required this.strokeWidth,
+    required this.amplitude,
+    required this.wavelength,
+    required this.steps,
+    required this.gapWidth,
+  });
+
+  final double? value;
+  final Color active;
+  final Color track;
+  final double phase;
+  final double strokeWidth;
+  final double amplitude;
+  final double wavelength;
+  final int steps;
+  final double gapWidth;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = size.center(Offset.zero);
+    final radius = (math.min(size.width, size.height) - strokeWidth) / 2;
+    if (radius <= 0) return;
+
+    const startAngle = -math.pi / 2;
+    final sweep = value == null
+        ? 2 * math.pi
+        : value!.clamp(0.0, 1.0) * 2 * math.pi;
+    final endAngle = startAngle + sweep;
+
+    final gapArcLen = sweep == 0 ? 0.0 : gapWidth;
+    final gapAngle = gapArcLen / radius;
+    final rect = Rect.fromCircle(center: center, radius: radius);
+
+    // Draw the track arc with a gap at both ends of the active arc
+    if (value != null && value! < 1.0) {
+      final trackSweep = 2 * math.pi - sweep - 2 * gapAngle;
+      if (trackSweep > 0) {
+        canvas.drawArc(
+          rect,
+          endAngle + gapAngle,
+          trackSweep,
+          false,
+          Paint()
+            ..color = track
+            ..style = PaintingStyle.stroke
+            ..strokeWidth = strokeWidth
+            ..strokeCap = StrokeCap.round,
+        );
+      }
+    }
+
+    if (sweep <= 0) return;
+
+    // Draw the wavy active arc
+
+    final wavePaint = Paint()
+      ..color = active
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth
+      ..strokeCap = StrokeCap.round;
+
+    final path = Path();
+    for (int i = 0; i <= steps; i++) {
+      final t = i / steps;
+      final angle = startAngle + sweep * t;
+      final arcLen = radius * (angle - startAngle);
+      final wave = math.sin(arcLen / wavelength * 2 * math.pi + phase);
+
+      double r = radius + amplitude * wave;
+
+      // Taper the wave amplitude to 0 at the end of the arc
+      final taperLen = wavelength / 2;
+      final arcToEnd = radius * (endAngle - angle);
+      if (arcToEnd < taperLen && arcToEnd >= 0) {
+        final taperFactor = math.sin((arcToEnd / taperLen) * math.pi / 2);
+        r = radius + (amplitude * taperFactor) * wave;
+      }
+
+      final x = center.dx + r * math.cos(angle);
+      final y = center.dy + r * math.sin(angle);
+      if (i == 0) {
+        path.moveTo(x, y);
+      } else {
+        path.lineTo(x, y);
+      }
+    }
+    canvas.drawPath(path, wavePaint);
+  }
+
+  @override
+  bool shouldRepaint(_CircularRipplingWavyPainter oldDelegate) {
+    return oldDelegate.value != value ||
+        oldDelegate.active != active ||
+        oldDelegate.track != track ||
+        oldDelegate.phase != phase ||
+        oldDelegate.strokeWidth != strokeWidth ||
+        oldDelegate.amplitude != amplitude ||
+        oldDelegate.wavelength != wavelength ||
+        oldDelegate.steps != steps ||
+        oldDelegate.gapWidth != gapWidth;
+  }
+}

--- a/lib/components/rippling_wavy_progress/linear.dart
+++ b/lib/components/rippling_wavy_progress/linear.dart
@@ -1,0 +1,132 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
+
+/// A linear progress bar with a wavy pattern. Wraps
+/// [LinearProgressIndicatorM3E] and adds phase animation
+/// and smooth value transitions.
+class LinearRipplingWavyProgressIndicator extends StatefulWidget {
+  final double? value;
+  final LinearProgressM3ESize size;
+  final Color? activeColor;
+  final Color? trackColor;
+  final double inset;
+
+  /// Wave animation speed in cycles per second.
+  final double waveSpeed;
+
+  /// Progress below this value renders flat instead of wavy.
+  final double flatBelow;
+
+  /// Smooth transition duration when [value] changes.
+  final Duration dragDuration;
+
+  const LinearRipplingWavyProgressIndicator({
+    super.key,
+    this.value,
+    this.size = LinearProgressM3ESize.m,
+    this.activeColor,
+    this.trackColor,
+    this.inset = 10.0,
+    this.waveSpeed = 1.0,
+    this.flatBelow = 0.01,
+    this.dragDuration = const Duration(milliseconds: 500),
+  });
+
+  @override
+  State<LinearRipplingWavyProgressIndicator> createState() =>
+      _LinearRipplingWavyProgressState();
+}
+
+class _LinearRipplingWavyProgressState
+    extends State<LinearRipplingWavyProgressIndicator>
+    with TickerProviderStateMixin {
+  late final AnimationController _phaseController;
+  late final AnimationController _valueController;
+  late final Listenable _mergedListeners;
+
+  Duration _getDuration(double cyclesPerSecond) {
+    return Duration(
+      milliseconds: (1000 / cyclesPerSecond.clamp(0.001, double.infinity))
+          .round(),
+    );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _phaseController = AnimationController(
+      vsync: this,
+      duration: _getDuration(widget.waveSpeed),
+      lowerBound: 1e-10,
+      upperBound: 2 * math.pi,
+    )..repeat();
+    _valueController = AnimationController(
+      vsync: this,
+      duration: widget.dragDuration,
+      value: widget.value,
+    );
+    _mergedListeners = Listenable.merge([_phaseController, _valueController]);
+  }
+
+  @override
+  void didUpdateWidget(
+    covariant LinearRipplingWavyProgressIndicator oldWidget,
+  ) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.waveSpeed != widget.waveSpeed) {
+      _phaseController.duration = _getDuration(widget.waveSpeed);
+      if (_shouldAnimate) _phaseController.repeat();
+    }
+    if (oldWidget.value != widget.value && widget.value != null) {
+      _valueController.animateTo(
+        widget.value!,
+        duration: widget.dragDuration,
+        curve: Curves.easeOutCubic,
+      );
+    }
+    _updatePhaseAnimating();
+  }
+
+  bool get _shouldAnimate {
+    if (widget.value == null) return true;
+    return widget.value! >= widget.flatBelow;
+  }
+
+  void _updatePhaseAnimating() {
+    if (_shouldAnimate) {
+      if (!_phaseController.isAnimating) _phaseController.repeat();
+    } else {
+      if (_phaseController.isAnimating) _phaseController.stop();
+    }
+  }
+
+  @override
+  void dispose() {
+    _phaseController.dispose();
+    _valueController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _mergedListeners,
+      builder: (context, child) {
+        final displayedValue = widget.value == null
+            ? null
+            : _valueController.value;
+        return LinearProgressIndicatorM3E(
+          value: displayedValue,
+          shape: _shouldAnimate ? ProgressM3EShape.wavy : ProgressM3EShape.flat,
+          size: widget.size,
+          activeColor: widget.activeColor,
+          trackColor: widget.trackColor,
+          phase: _phaseController.value,
+          inset: widget.inset,
+        );
+      },
+    );
+  }
+}

--- a/lib/components/rippling_wavy_progress/linear.dart
+++ b/lib/components/rippling_wavy_progress/linear.dart
@@ -19,7 +19,7 @@ class LinearRipplingWavyProgressIndicator extends StatefulWidget {
   /// Progress below this value renders flat instead of wavy.
   final double flatBelow;
 
-  /// Smooth transition duration when [value] changes.
+  /// Smooth transition duration when [value] increases.
   final Duration dragDuration;
 
   const LinearRipplingWavyProgressIndicator({
@@ -79,12 +79,18 @@ class _LinearRipplingWavyProgressState
       _phaseController.duration = _getDuration(widget.waveSpeed);
       if (_shouldAnimate) _phaseController.repeat();
     }
-    if (oldWidget.value != widget.value && widget.value != null) {
-      _valueController.animateTo(
-        widget.value!,
-        duration: widget.dragDuration,
-        curve: Curves.easeOutCubic,
-      );
+
+    // Only animate when the value increases else snap
+    if (oldWidget.value != widget.value) {
+      if (widget.value == null || widget.value! <= _valueController.value) {
+        _valueController.value = widget.value ?? _valueController.lowerBound;
+      } else {
+        _valueController.animateTo(
+          widget.value!,
+          duration: widget.dragDuration,
+          curve: Curves.easeOutCubic,
+        );
+      }
     }
     _updatePhaseAnimating();
   }

--- a/lib/pages/apps.dart
+++ b/lib/pages/apps.dart
@@ -23,6 +23,8 @@ import 'package:obtainium/layout_breakpoints.dart';
 import 'package:obtainium/components/custom_app_bar.dart';
 import 'package:obtainium/components/generated_form.dart';
 import 'package:obtainium/components/generated_form_modal.dart';
+import 'package:obtainium/components/rippling_wavy_progress/circular.dart';
+import 'package:obtainium/components/rippling_wavy_progress/linear.dart';
 import 'package:obtainium/custom_errors.dart';
 import 'package:obtainium/main.dart';
 import 'package:obtainium/pages/additional_options_page.dart';
@@ -426,7 +428,7 @@ class _RefreshProgressBar extends StatelessWidget {
     // stop-dot at the end (per the M3E spec). The widget draws two
     // separate lanes (active above, track below) with a fixed gap so the
     // active and inactive segments never overlap.
-    return LinearProgressIndicatorM3E(
+    return LinearRipplingWavyProgressIndicator(
       value: loadingApps
           ? null
           : (progressDenominator > 0
@@ -765,14 +767,12 @@ class _AppListItem extends StatelessWidget {
             children: [
               SizedBox.square(
                 dimension: 48,
-                child: CircularProgressIndicatorM3E(
+                child: CircularRipplingWavyProgressIndicator(
                   value: progressValue,
                   size: CircularProgressM3ESize.s,
-                  shape: ProgressM3EShape.wavy,
                   activeColor: isInstalling
                       ? colorScheme.secondary
                       : colorScheme.primary,
-                  trackColor: colorScheme.surfaceContainerHighest,
                 ),
               ),
               if (!isInstalling)
@@ -2834,6 +2834,10 @@ class AppsPageState extends State<AppsPage> {
             if (!context.mounted) return <App>[];
             showError(e is Map ? e['errors'] : e, context);
             return <App>[];
+          })
+          .whenComplete(() {
+            // Allow the progress bar to reach 100% before dismissing.
+            return Future.delayed(const Duration(milliseconds: 500));
           })
           .whenComplete(() {
             setState(() {


### PR DESCRIPTION
- The linear progress indicator bugged me as that felt laggy whenever checking for updates.
- Similar thing with when downloading apps, with the circular progress indicator.
- So, I thought of causing ripples along the waves can make it better. The linear rippling progress is wrapper around `LinearProgressIndicatorM3E` while the circular one uses a custom painter because there was no option to add a ripply factor to a rotational progress indicator (`CircularProgressIndicatorM3E`).
- Both the new widgets (`LinearRipplingWavyProgressIndicator` and `CircularRipplingWavyProgressIndicator`) have similar APIs to what the above ones have (plus more except for shape). Also, the latter have internal animation controllers which are triggered on some constraints consisting of `phase` to be `0.0`. The former sets the lowerBound to `1e-10` so it never touches `0.0` and animations are only handled by them.
- Also, noticed that the track color for the circular progress wasn't visible hence, removed the explicit color. It's handled by the `ColorScheme.onSurfaceVariant.withValues(alpha: 0.24)` which is the default for the **M3E** one.