### PR TITLE
Auto-detect any Forgejo instance, not just Codeberg

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -212,6 +212,13 @@ Override the contract methods you need:
 - `getSource(url)`: first tries host-regex matching against sources with `hosts`, then
   falls back to host-less sources via `sourceSpecificStandardizeURL` — **`HTML()` is
   always last** as the catch-all. Match errors are logged, never swallowed silently.
+- Matching is **synchronous and cached**, so a source that can only be identified by
+  asking the server cannot be resolved here. `lib/services/forgejo_detection.dart` is
+  the pattern for that case: it probes a candidate host's API where a URL first enters
+  the app (the Add App form and `getAppsByURLNaive`) and, on a match, selects the
+  source via the per-app `overrideSource` — which is persisted, exported, and editable
+  in the UI, so nothing new has to be stored or migrated. It runs **only** for URLs
+  that would otherwise fall through to `HTML()`.
 - `getApp(...)`: orchestrates `getLatestAPKDetails` → version extraction → APK filtering
   → arch filtering → builds the final `App`. This is where `versionExtractionRegEx`,
   `releaseDateAsVersion`, `apkFilterRegEx`, `autoApkFilterByArch`, app-id inference, and

--- a/lib/app_sources/codeberg.dart
+++ b/lib/app_sources/codeberg.dart
@@ -10,6 +10,13 @@ class Codeberg extends AppSource {
   final GitHub _gh = GitHub(hostChanged: true);
   Codeberg() {
     name = 'Forgejo (Codeberg)';
+    // codeberg.org is the only Forgejo instance matched by host, and this
+    // list is deliberately not grown into a curated allowlist: any other
+    // instance is recognized at add time by ForgejoDetector (see
+    // lib/services/forgejo_detection.dart), which probes the host's API and
+    // then selects this source through `overrideSource`. Everything below
+    // reads the host off the app's own URL, so it works unchanged for any
+    // instance once the source has been selected.
     hosts = ['codeberg.org'];
     canSearch = true;
     // Same deal as GitHub: the repo is right there, so try to read the app id

--- a/lib/app_sources/codeberg.dart
+++ b/lib/app_sources/codeberg.dart
@@ -10,14 +10,16 @@ class Codeberg extends AppSource {
   final GitHub _gh = GitHub(hostChanged: true);
   Codeberg() {
     name = 'Forgejo (Codeberg)';
-    // codeberg.org is the only Forgejo instance matched by host, and this
-    // list is deliberately not grown into a curated allowlist: any other
-    // instance is recognized at add time by ForgejoDetector (see
-    // lib/services/forgejo_detection.dart), which probes the host's API and
-    // then selects this source through `overrideSource`. Everything below
-    // reads the host off the app's own URL, so it works unchanged for any
-    // instance once the source has been selected.
-    hosts = ['codeberg.org'];
+    // Forgejo instances known well enough to be worth matching without a
+    // network round-trip. This list is an optimization, not the mechanism:
+    // an instance that is NOT listed here is still recognized at add time by
+    // ForgejoDetector (lib/services/forgejo_detection.dart), which probes the
+    // host's API and selects this source through `overrideSource`.
+    //
+    // More entries are welcome - add the bare host and nothing else, since
+    // every per-app request below derives its host from the app's own URL
+    // (`search` is the documented exception, and necessarily so).
+    hosts = ['codeberg.org', 'codefloe.com'];
     canSearch = true;
     // Same deal as GitHub: the repo is right there, so try to read the app id
     // out of it instead of making the user download an APK first. Optional

--- a/lib/app_sources/codeberg.dart
+++ b/lib/app_sources/codeberg.dart
@@ -27,15 +27,24 @@ class Codeberg extends AppSource {
 
   /// Forgejo's contents endpoint is GitHub's, path for path and payload for
   /// payload (base64 `content`), so the shared decoder applies unchanged.
+  ///
+  /// The API host is derived from the app's own URL rather than from `hosts`,
+  /// matching [getLatestAPKDetails]. `hosts[0]` would happen to be right today
+  /// (an overridden source has its host list replaced with the single real
+  /// host by [SourceProvider.getSource]), but it silently becomes the wrong
+  /// instance the moment `hosts` holds more than one entry - inferring an app
+  /// ID for a repo on one instance from a same-named repo on another.
   @override
   Future<String?> tryInferringAppId(
     String standardUrl, {
     Map<String, dynamic> additionalSettings = const {},
   }) async {
-    final String repoPath = Uri.parse(standardUrl).path;
+    final Uri standardUri = Uri.parse(standardUrl);
     return inferAppIdFromGradleFiles((String path) async {
       final res = await sourceRequest(
-        'https://${hosts[0]}/api/v1/repos$repoPath/contents/$path',
+        standardUri
+            .replace(path: '/api/v1/repos${standardUri.path}/contents/$path')
+            .toString(),
         additionalSettings,
       );
       if (res.statusCode != 200) return null;
@@ -108,6 +117,12 @@ class Codeberg extends AppSource {
     }
   }
 
+  /// Unlike every other request this source makes, a search has no app URL to
+  /// take a host from, so it necessarily targets one instance: `hosts[0]`, the
+  /// canonical one. Should `hosts` ever hold more than one entry, this stays
+  /// deliberate rather than accidental - searching every known Forgejo instance
+  /// would mean a fan-out of one request per host per keystroke, and instances
+  /// have no shared index to search instead.
   @override
   Future<Map<String, List<String>>> search(
     String query, {

--- a/lib/pages/add_app.dart
+++ b/lib/pages/add_app.dart
@@ -176,11 +176,12 @@ class AddAppPageState extends State<AddAppPage> {
   Timer? _customAppIdDebounce;
   static const Duration _customAppIdDebounceDelay = Duration(milliseconds: 400);
 
-  /// Debounced auto-detection of Forgejo instances other than codeberg.org.
+  /// Debounced auto-detection of Forgejo instances ObtainX has no host entry
+  /// for.
   ///
-  /// Only codeberg.org matches the Forgejo source by host, so a repo URL on
-  /// any other instance lands on the [HTML] catch-all and is scraped as a web
-  /// page. [ForgejoDetector] asks the instance's API instead and, when it
+  /// The Forgejo source matches only the handful of hosts it lists, so a repo
+  /// URL on any other instance lands on the [HTML] catch-all and is scraped as
+  /// a web page. [ForgejoDetector] asks the instance's API instead and, when it
   /// answers like Forgejo, switches this form over to the Forgejo source -
   /// the same thing the user can do by hand under "Override source".
   /// Debounced because [changeUserInput] runs on every keystroke while the

--- a/lib/pages/add_app.dart
+++ b/lib/pages/add_app.dart
@@ -5,6 +5,7 @@ import 'package:expressive_loading_indicator/expressive_loading_indicator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show ScrollCacheExtent;
 import 'package:obtainium/app_sources/github.dart';
+import 'package:obtainium/app_sources/html.dart';
 import 'package:obtainium/layout_breakpoints.dart';
 import 'package:obtainium/components/app_page_section_title.dart';
 import 'package:obtainium/components/bulk_add_widget.dart';
@@ -27,6 +28,7 @@ import 'package:obtainium/providers/notifications_provider.dart';
 import 'package:obtainium/providers/settings_provider.dart';
 import 'package:obtainium/providers/source_provider.dart';
 import 'package:obtainium/providers/virustotal_provider.dart';
+import 'package:obtainium/services/forgejo_detection.dart';
 import 'package:obtainium/store_source_icons.dart';
 import 'package:obtainium/theme/app_dialog_theme.dart';
 import 'package:obtainium/theme/app_form_field_styles.dart';
@@ -173,6 +175,21 @@ class AddAppPageState extends State<AddAppPage> {
   bool _customAppIdEntered = false;
   Timer? _customAppIdDebounce;
   static const Duration _customAppIdDebounceDelay = Duration(milliseconds: 400);
+
+  /// Debounced auto-detection of Forgejo instances other than codeberg.org.
+  ///
+  /// Only codeberg.org matches the Forgejo source by host, so a repo URL on
+  /// any other instance lands on the [HTML] catch-all and is scraped as a web
+  /// page. [ForgejoDetector] asks the instance's API instead and, when it
+  /// answers like Forgejo, switches this form over to the Forgejo source -
+  /// the same thing the user can do by hand under "Override source".
+  /// Debounced because [changeUserInput] runs on every keystroke while the
+  /// check is a network round-trip.
+  Timer? _forgejoDetectDebounce;
+  static const Duration _forgejoDetectDebounceDelay = Duration(
+    milliseconds: 700,
+  );
+  String? _forgejoDetectLastProbedInput;
   List<String> pickedCategories = [];
   SourceProvider sourceProvider = SourceProvider();
   final GlobalKey _urlFieldKey = GlobalKey();
@@ -397,6 +414,7 @@ class AddAppPageState extends State<AddAppPage> {
   @override
   void dispose() {
     _customAppIdDebounce?.cancel();
+    _forgejoDetectDebounce?.cancel();
     _urlFieldController.dispose();
     _urlFieldFocusNode.dispose();
     _searchSomeSourcesController.dispose();
@@ -428,6 +446,47 @@ class AddAppPageState extends State<AddAppPage> {
   Set<String> _getSearchSelectedStores() {
     _searchSelectedStores ??= {};
     return _searchSelectedStores!;
+  }
+
+  /// Switches the form over to the Forgejo source when the entered URL turns
+  /// out to be a repository on a Forgejo instance ObtainX does not know by
+  /// host.
+  ///
+  /// Runs only while the URL is still headed for the [HTML] catch-all and the
+  /// user has not picked an override themselves, and re-checks both once the
+  /// probe returns - the field may have moved on while it was in flight.
+  void _scheduleForgejoDetection() {
+    _forgejoDetectDebounce?.cancel();
+    if (pickedSourceOverride != null || pickedSource is! HTML) return;
+    final String input = userInput.trim();
+    if (input.isEmpty || input == _forgejoDetectLastProbedInput) return;
+    _forgejoDetectDebounce = Timer(_forgejoDetectDebounceDelay, () async {
+      if (!mounted ||
+          pickedSourceOverride != null ||
+          pickedSource is! HTML ||
+          userInput.trim() != input) {
+        return;
+      }
+      _forgejoDetectLastProbedInput = input;
+      final ForgejoDetection? detection =
+          await ForgejoDetector.detectIfUnmatched(input);
+      if (!mounted ||
+          detection == null ||
+          pickedSourceOverride != null ||
+          userInput.trim() != input) {
+        return;
+      }
+      // Adopt the repo root: an overridden source keeps the URL's own path
+      // verbatim when building API calls, so anything past <owner>/<repo>
+      // (/releases, /src/branch/main, a .git suffix) has to go.
+      changeUserInput(
+        detection.canonicalUrl,
+        true,
+        false,
+        updateUrlInput: true,
+        overrideSource: detection.sourceIdentifier,
+      );
+    });
   }
 
   bool _isUrlInputValid(String value) {
@@ -506,10 +565,13 @@ class AddAppPageState extends State<AddAppPage> {
           inferAppIdIfOptional = true;
         }
       });
+      _scheduleForgejoDetection();
     }
   }
 
   void _resetUrlModeInput() {
+    _forgejoDetectDebounce?.cancel();
+    _forgejoDetectLastProbedInput = null;
     userInput = '';
     pickedSourceOverride = null;
     previousPickedSourceOverride = null;
@@ -1858,6 +1920,13 @@ class AddAppPageState extends State<AddAppPage> {
           children: [
             Expanded(
               child: GeneratedForm(
+                // GeneratedForm reads item values once, in initForm, and only
+                // re-reads them when its key changes - so without this the
+                // dropdown would keep showing "None" after Forgejo
+                // auto-detection sets the override for the user.
+                key: ValueKey<String>(
+                  'overrideSource:${pickedSourceOverride ?? ''}',
+                ),
                 outlinedInputFields: true,
                 items: [
                   [

--- a/lib/providers/source_provider.dart
+++ b/lib/providers/source_provider.dart
@@ -45,6 +45,7 @@ import 'package:obtainium/custom_errors.dart';
 import 'package:obtainium/app_sources/githubstars.dart';
 import 'package:obtainium/providers/logs_provider.dart';
 import 'package:obtainium/providers/settings_provider.dart';
+import 'package:obtainium/services/forgejo_detection.dart';
 import 'package:obtainium/version/version_detection_mode.dart';
 import 'package:obtainium/version/version_strings.dart';
 
@@ -1922,11 +1923,36 @@ class SourceProvider {
             if (alreadyAddedUrls.contains(url)) {
               throw ObtainiumError(tr('appAlreadyAdded'));
             }
-            final source = sourceOverride ?? getSource(url);
+            final AppSource source;
+            final bool sourceIsOverriden;
+            final String appUrl;
+            if (sourceOverride != null) {
+              source = sourceOverride;
+              sourceIsOverriden = true;
+              appUrl = url;
+            } else {
+              // A repository on a Forgejo instance other than codeberg.org
+              // matches no source by host, so it would be imported as a plain
+              // HTML page. Detect it here too, so a bulk import gets the same
+              // treatment as a manual add - see [ForgejoDetector].
+              final detection = await ForgejoDetector.detectIfUnmatched(url);
+              if (detection != null) {
+                appUrl = detection.canonicalUrl;
+                source = getSource(
+                  appUrl,
+                  overrideSource: detection.sourceIdentifier,
+                );
+                sourceIsOverriden = true;
+              } else {
+                appUrl = url;
+                source = getSource(appUrl);
+                sourceIsOverriden = false;
+              }
+            }
             return await getApp(
               source,
-              url,
-              sourceIsOverriden: sourceOverride != null,
+              appUrl,
+              sourceIsOverriden: sourceIsOverriden,
               getDefaultValuesFromFormItems(
                 source.combinedAppSpecificSettingFormItems,
               ),

--- a/lib/providers/source_provider.dart
+++ b/lib/providers/source_provider.dart
@@ -1931,10 +1931,11 @@ class SourceProvider {
               sourceIsOverriden = true;
               appUrl = url;
             } else {
-              // A repository on a Forgejo instance other than codeberg.org
-              // matches no source by host, so it would be imported as a plain
-              // HTML page. Detect it here too, so a bulk import gets the same
-              // treatment as a manual add - see [ForgejoDetector].
+              // A repository on a Forgejo instance that is not in the
+              // Forgejo source's host list matches no source by host, so it
+              // would be imported as a plain HTML page. Detect it here too, so
+              // a bulk import gets the same treatment as a manual add - see
+              // [ForgejoDetector].
               final detection = await ForgejoDetector.detectIfUnmatched(url);
               if (detection != null) {
                 appUrl = detection.canonicalUrl;

--- a/lib/services/forgejo_detection.dart
+++ b/lib/services/forgejo_detection.dart
@@ -1,0 +1,295 @@
+// Generic Forgejo/Gitea instance detection.
+//
+// ObtainX resolves sources by hostname (see [SourceProvider.getSource]) and the
+// Forgejo adapter ([Codeberg]) declares exactly one host: codeberg.org. Every
+// other Forgejo instance therefore fell through to the [HTML] catch-all, so
+// ObtainX scraped the rendered release page instead of asking the instance's
+// JSON API - heavier, more fragile, and the direct cause of the rate limiting
+// CodeFloe's maintainers reported
+// (https://forum.codefloe.com/t/obtainium-hitting-rate-limit/148). They asked
+// for auto-detection of any Forgejo host rather than a Codeberg special case;
+// this is that (issue #254).
+//
+// Source matching itself is synchronous and cached, so the detection cannot
+// live inside it - a probe is a network round-trip. Instead it runs where a URL
+// first enters the app (the Add App form and bulk URL import) and, on success,
+// selects the Forgejo adapter through the existing per-app `overrideSource`
+// mechanism. That is precisely what a user does by hand today with
+// "Override source -> Forgejo (Codeberg)", so the result persists with the app,
+// survives export/import, and stays editable in the UI - no new stored state,
+// no migration, and a wrong guess is one dropdown away from being corrected.
+//
+// The probe is two requests, and stops at the first:
+//
+//   1. GET <origin>/api/v1/version
+//      -> 200 {"version": "16.0.2"}
+//   2. GET <origin>/api/v1/repos/<owner>/<repo>
+//      -> 200 {"name": ..., "full_name": "<owner>/<repo>", "owner": {...}}
+//
+// Step 1 rules out virtually every non-forge host in a single request, and its
+// verdict is cached per authority for the process lifetime - so importing
+// twenty repos from one instance probes that instance once. Step 2 confirms the
+// path really is a repository and that the API answers in the shape [Codeberg]
+// needs before any URL is rewritten. Both must pass.
+
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:http/http.dart' as http;
+import 'package:obtainium/app_sources/codeberg.dart';
+import 'package:obtainium/app_sources/html.dart';
+import 'package:obtainium/providers/source_provider.dart';
+
+/// The [AppSource.sourceIdentifier] of the Forgejo adapter - the value
+/// stored in [App.overrideSource] for a detected instance. Read off the
+/// source itself so a class rename can never silently desync the two.
+final String forgejoSourceIdentifier = Codeberg().sourceIdentifier;
+
+/// A URL confirmed to point at a repository on a Forgejo/Gitea instance.
+class ForgejoDetection {
+  const ForgejoDetection({required this.canonicalUrl, required this.authority});
+
+  /// The repository root: `<scheme>://<authority>/<owner>/<repo>`.
+  ///
+  /// [Codeberg] builds its API paths straight off the app URL's path, so a URL
+  /// carrying anything extra (`/releases`, `/src/branch/main`, a `.git` suffix)
+  /// would produce a nonsense API path. `standardizeUrl` cannot trim it
+  /// either, because it skips source-specific standardization whenever the
+  /// host has been overridden. Callers therefore replace the user's URL
+  /// with this one.
+  final String canonicalUrl;
+
+  /// Host, plus port when the instance runs on a non-default one.
+  final String authority;
+
+  /// The value to pass as `overrideSource` for [canonicalUrl].
+  String get sourceIdentifier => forgejoSourceIdentifier;
+}
+
+/// The `<owner>/<repo>` reading of a URL, and the endpoints it implies.
+@visibleForTesting
+class ForgejoRepoCandidate {
+  const ForgejoRepoCandidate({
+    required this.origin,
+    required this.authority,
+    required this.owner,
+    required this.repo,
+  });
+
+  /// `<scheme>://<authority>`.
+  final String origin;
+  final String authority;
+  final String owner;
+  final String repo;
+
+  String get canonicalUrl => '$origin/$owner/$repo';
+  String get versionProbeUrl => '$origin/api/v1/version';
+  String get repoProbeUrl => '$origin/api/v1/repos/$owner/$repo';
+}
+
+/// Fetches [url] and returns the response. Injected in tests; production uses
+/// [ForgejoDetector.defaultProbe].
+typedef ForgejoProbe = Future<http.Response> Function(String url);
+
+class ForgejoDetector {
+  ForgejoDetector._();
+
+  static const Duration probeTimeout = Duration(seconds: 8);
+
+  /// A Forgejo `/api/v1/version` body is a few dozen bytes and a repo payload a
+  /// few kilobytes. Anything larger is some other server's response and is not
+  /// worth handing to [jsonDecode].
+  static const int _maxProbeBodyLength = 256 * 1024;
+
+  /// Forgejo routes these top-level paths itself, so `/<segment>/<x>` is never
+  /// `<owner>/<repo>` for them. Skipping them avoids a pointless request.
+  static const Set<String> _reservedOwnerSegments = <String>{
+    'admin',
+    'api',
+    'assets',
+    'attachments',
+    'avatar',
+    'avatars',
+    'explore',
+    'issues',
+    'login',
+    'milestones',
+    'notifications',
+    'org',
+    'pulls',
+    'repo',
+    'user',
+    'users',
+  };
+
+  /// Forgejo and Gitea both report a dotted numeric version (`16.0.2`,
+  /// `16.0.0-dev-694-33ae492b+gitea-1.22.0`, `1.22.0`). Requiring that shape
+  /// rather than any non-empty string keeps an unrelated server that happens to
+  /// answer `/api/v1/version` from being mistaken for a forge, while staying
+  /// tolerant of whatever suffixes future releases add.
+  static final RegExp _versionShape = RegExp(r'^\d+\.\d+');
+
+  /// Per-authority result of step 1, for this process only. Absent means
+  /// "not asked yet"; a failed request is deliberately not recorded, so
+  /// being offline at the wrong moment does not blacklist an instance for
+  /// the whole session.
+  static final Map<String, bool> _authorityRunsForgejoApi = <String, bool>{};
+
+  @visibleForTesting
+  static void resetProbeCache() => _authorityRunsForgejoApi.clear();
+
+  /// Detects a Forgejo repository, but only for URLs that ObtainX would
+  /// otherwise hand to the generic [HTML] scraper. A URL that already resolves
+  /// to a real source (github.com, codeberg.org, an F-Droid repo, ...) is left
+  /// alone - this exists to rescue the fallback case, not to second-guess
+  /// working matches.
+  static Future<ForgejoDetection?> detectIfUnmatched(
+    String url, {
+    ForgejoProbe? probe,
+  }) async {
+    if (!fallsBackToGenericHtml(url)) return null;
+    return detect(url, probe: probe);
+  }
+
+  /// Whether [url] resolves to the [HTML] catch-all (or to no source at all).
+  static bool fallsBackToGenericHtml(String url) {
+    try {
+      return SourceProvider().getSourceTemplate(url) is HTML;
+    } catch (_) {
+      // Not a URL any source accepts - nothing to detect.
+      return false;
+    }
+  }
+
+  /// Runs the probe regardless of which source [url] currently resolves to.
+  static Future<ForgejoDetection?> detect(
+    String url, {
+    ForgejoProbe? probe,
+  }) async {
+    final ForgejoRepoCandidate? candidate = candidateFromUrl(url);
+    if (candidate == null) return null;
+    final ForgejoProbe fetch = probe ?? defaultProbe;
+    if (!await _authorityAnswersForgejoApi(candidate, fetch)) return null;
+    final http.Response? repoResponse = await _probe(
+      candidate.repoProbeUrl,
+      fetch,
+    );
+    if (repoResponse == null || repoResponse.statusCode != 200) return null;
+    if (!looksLikeRepoPayload(repoResponse.body)) return null;
+    return ForgejoDetection(
+      canonicalUrl: candidate.canonicalUrl,
+      authority: candidate.authority,
+    );
+  }
+
+  /// Reads [url] as `<scheme>://<authority>/<owner>/<repo>`, ignoring anything
+  /// after the repo name, or returns null when it cannot possibly be one.
+  @visibleForTesting
+  static ForgejoRepoCandidate? candidateFromUrl(String url) {
+    // Accepts scheme-less input the same way the Add App field does.
+    final String? prepared = _preStandardizeOrNull(url);
+    if (prepared == null) return null;
+    final Uri? uri = Uri.tryParse(prepared);
+    if (uri == null) return null;
+    final String scheme = uri.scheme.toLowerCase();
+    if (scheme != 'http' && scheme != 'https') return null;
+    if (uri.host.isEmpty) return null;
+    final List<String> segments = uri.pathSegments
+        .where((String segment) => segment.isNotEmpty)
+        .toList();
+    if (segments.length < 2) return null;
+    final String owner = segments[0];
+    if (_reservedOwnerSegments.contains(owner.toLowerCase())) return null;
+    String repo = segments[1];
+    if (repo.length > 4 && repo.toLowerCase().endsWith('.git')) {
+      repo = repo.substring(0, repo.length - 4);
+    }
+    if (owner.isEmpty || repo.isEmpty) return null;
+    final String authority = uri.hasPort
+        ? '${uri.host}:${uri.port}'
+        : uri.host;
+    return ForgejoRepoCandidate(
+      origin: '$scheme://$authority',
+      authority: authority,
+      owner: owner,
+      repo: repo,
+    );
+  }
+
+  /// [preStandardizeUrl] throws on input that is not URL-shaped at all.
+  static String? _preStandardizeOrNull(String url) {
+    try {
+      return preStandardizeUrl(url.trim());
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Step 1, memoized per authority.
+  static Future<bool> _authorityAnswersForgejoApi(
+    ForgejoRepoCandidate candidate,
+    ForgejoProbe fetch,
+  ) async {
+    final bool? cached = _authorityRunsForgejoApi[candidate.authority];
+    if (cached != null) return cached;
+    final http.Response? response = await _probe(
+      candidate.versionProbeUrl,
+      fetch,
+    );
+    // A request that never completed (offline, DNS failure, timeout) is not a
+    // verdict, so leave the authority uncached and let a later attempt decide.
+    if (response == null) return false;
+    final bool answers =
+        response.statusCode == 200 && looksLikeVersionPayload(response.body);
+    _authorityRunsForgejoApi[candidate.authority] = answers;
+    return answers;
+  }
+
+  static Future<http.Response?> _probe(String url, ForgejoProbe fetch) async {
+    try {
+      return await fetch(url).timeout(probeTimeout);
+    } catch (_) {
+      // Any failure just means "not detected"; the URL still works as HTML.
+      return null;
+    }
+  }
+
+  /// Goes through [AppSource.sourceRequest] rather than a bare `http.get`
+  /// so the probe inherits the app's redirect cap and TLS handling.
+  /// [Codeberg] adds no headers of its own, so this is an unauthenticated
+  /// GET.
+  static Future<http.Response> defaultProbe(String url) =>
+      Codeberg().sourceRequest(url, const <String, dynamic>{});
+
+  @visibleForTesting
+  static bool looksLikeVersionPayload(String body) {
+    final Map<String, dynamic>? json = _decodeObject(body);
+    if (json == null) return false;
+    final dynamic version = json['version'];
+    return version is String && _versionShape.hasMatch(version.trim());
+  }
+
+  @visibleForTesting
+  static bool looksLikeRepoPayload(String body) {
+    final Map<String, dynamic>? json = _decodeObject(body);
+    if (json == null) return false;
+    final dynamic fullName = json['full_name'];
+    final dynamic owner = json['owner'];
+    // The subset of the (GitHub-shaped) repo payload [Codeberg] relies on.
+    return json['name'] is String &&
+        fullName is String &&
+        fullName.contains('/') &&
+        owner is Map &&
+        owner['login'] is String;
+  }
+
+  static Map<String, dynamic>? _decodeObject(String body) {
+    if (body.isEmpty || body.length > _maxProbeBodyLength) return null;
+    try {
+      final dynamic decoded = jsonDecode(body);
+      return decoded is Map<String, dynamic> ? decoded : null;
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/lib/services/forgejo_detection.dart
+++ b/lib/services/forgejo_detection.dart
@@ -1,8 +1,8 @@
 // Generic Forgejo/Gitea instance detection.
 //
-// ObtainX resolves sources by hostname (see [SourceProvider.getSource]) and the
-// Forgejo adapter ([Codeberg]) declares exactly one host: codeberg.org. Every
-// other Forgejo instance therefore fell through to the [HTML] catch-all, so
+// ObtainX resolves sources by hostname (see [SourceProvider.getSource]), and
+// the Forgejo adapter ([Codeberg]) can only name hosts someone has added to it.
+// Every instance not on that list fell through to the [HTML] catch-all, so
 // ObtainX scraped the rendered release page instead of asking the instance's
 // JSON API - heavier, more fragile, and the direct cause of the rate limiting
 // CodeFloe's maintainers reported

--- a/test/forgejo_detection_test.dart
+++ b/test/forgejo_detection_test.dart
@@ -1,0 +1,381 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:obtainium/app_sources/codeberg.dart';
+import 'package:obtainium/services/forgejo_detection.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// What codefloe.com actually answers at /api/v1/version (checked 2026-08-22).
+const String _forgejoVersionBody = '{"version":"16.0.2"}';
+
+/// What codeberg.org answers - same endpoint, longer version string.
+const String _codebergVersionBody =
+    '{"version":"16.0.0-dev-694-33ae492b+gitea-1.22.0"}';
+
+String _repoBody(String host, String owner, String repo) => jsonEncode({
+  'id': 1234,
+  'name': repo,
+  'full_name': '$owner/$repo',
+  'owner': <String, dynamic>{'login': owner, 'id': 7},
+  'html_url': 'https://$host/$owner/$repo',
+});
+
+/// Answers the two probe endpoints from [responses]; anything else 404s, the
+/// way a host that is not a forge would. Records every URL it was asked for.
+class _FakeForge {
+  _FakeForge(this.responses);
+
+  final Map<String, http.Response> responses;
+  final List<String> requested = <String>[];
+
+  Future<http.Response> probe(String url) async {
+    requested.add(url);
+    return responses[url] ?? http.Response('<html>Not Found</html>', 404);
+  }
+}
+
+_FakeForge _workingForge({
+  String host = 'codefloe.com',
+  String owner = 'SnappTechnology',
+  String repo = 'NextCloudTalkNext',
+}) => _FakeForge(<String, http.Response>{
+  'https://$host/api/v1/version': http.Response(_forgejoVersionBody, 200),
+  'https://$host/api/v1/repos/$owner/$repo': http.Response(
+    _repoBody(host, owner, repo),
+    200,
+  ),
+});
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    ForgejoDetector.resetProbeCache();
+  });
+
+  group('candidateFromUrl', () {
+    test('reads owner and repo off a repo root', () {
+      final ForgejoRepoCandidate? candidate = ForgejoDetector.candidateFromUrl(
+        'https://codefloe.com/SnappTechnology/NextCloudTalkNext',
+      );
+      expect(candidate, isNotNull);
+      expect(candidate!.authority, 'codefloe.com');
+      expect(candidate.owner, 'SnappTechnology');
+      expect(candidate.repo, 'NextCloudTalkNext');
+      expect(
+        candidate.canonicalUrl,
+        'https://codefloe.com/SnappTechnology/NextCloudTalkNext',
+      );
+      expect(candidate.versionProbeUrl, 'https://codefloe.com/api/v1/version');
+      expect(
+        candidate.repoProbeUrl,
+        'https://codefloe.com/api/v1/repos/SnappTechnology/NextCloudTalkNext',
+      );
+    });
+
+    test('drops everything past the repo name', () {
+      // The overridden source keeps the URL's path verbatim when building API
+      // calls, so /releases would become .../repos/owner/repo/releases.
+      for (final String url in <String>[
+        'https://codefloe.com/owner/repo/releases',
+        'https://codefloe.com/owner/repo/src/branch/main',
+        'https://codefloe.com/owner/repo/releases/tag/v1.2.3',
+      ]) {
+        expect(
+          ForgejoDetector.candidateFromUrl(url)?.canonicalUrl,
+          'https://codefloe.com/owner/repo',
+          reason: url,
+        );
+      }
+    });
+
+    test('strips a .git clone suffix', () {
+      expect(
+        ForgejoDetector.candidateFromUrl(
+          'https://codefloe.com/owner/repo.git',
+        )?.repo,
+        'repo',
+      );
+      // A repo genuinely named ".git" keeps its name rather than emptying out.
+      expect(
+        ForgejoDetector.candidateFromUrl(
+          'https://codefloe.com/owner/.git',
+        )?.repo,
+        '.git',
+      );
+    });
+
+    test('accepts scheme-less input like the Add App field does', () {
+      expect(
+        ForgejoDetector.candidateFromUrl('codefloe.com/owner/repo')?.origin,
+        'https://codefloe.com',
+      );
+    });
+
+    test('keeps a non-default port', () {
+      final ForgejoRepoCandidate? candidate = ForgejoDetector.candidateFromUrl(
+        'http://git.example.com:3000/owner/repo',
+      );
+      expect(candidate?.authority, 'git.example.com:3000');
+      expect(candidate?.origin, 'http://git.example.com:3000');
+      expect(
+        candidate?.versionProbeUrl,
+        'http://git.example.com:3000/api/v1/version',
+      );
+    });
+
+    test('rejects what cannot be a repo path', () {
+      expect(ForgejoDetector.candidateFromUrl('https://codefloe.com'), isNull);
+      expect(
+        ForgejoDetector.candidateFromUrl('https://codefloe.com/owner'),
+        isNull,
+      );
+      expect(ForgejoDetector.candidateFromUrl('not a url'), isNull);
+      expect(ForgejoDetector.candidateFromUrl(''), isNull);
+    });
+
+    test("rejects Forgejo's own top-level routes as owners", () {
+      for (final String url in <String>[
+        'https://codefloe.com/explore/repos',
+        'https://codefloe.com/user/settings',
+        'https://codefloe.com/api/v1/version',
+      ]) {
+        expect(ForgejoDetector.candidateFromUrl(url), isNull, reason: url);
+      }
+    });
+  });
+
+  group('payload shape', () {
+    test('accepts the version payloads Forgejo and Gitea actually send', () {
+      expect(
+        ForgejoDetector.looksLikeVersionPayload(_forgejoVersionBody),
+        true,
+      );
+      expect(
+        ForgejoDetector.looksLikeVersionPayload(_codebergVersionBody),
+        true,
+      );
+      expect(
+        ForgejoDetector.looksLikeVersionPayload('{"version":"1.22.0"}'),
+        true,
+      );
+    });
+
+    test('rejects anything that is not a forge version response', () {
+      for (final String body in <String>[
+        '',
+        'not json',
+        '<html><body>hi</body></html>',
+        '{}',
+        '{"version":""}',
+        '{"version":"unknown"}',
+        '{"version":123}',
+        '{"api":"v1"}',
+        '["16.0.2"]',
+      ]) {
+        expect(
+          ForgejoDetector.looksLikeVersionPayload(body),
+          false,
+          reason: body,
+        );
+      }
+    });
+
+    test('accepts a repo payload in the shape Codeberg reads', () {
+      expect(
+        ForgejoDetector.looksLikeRepoPayload(
+          _repoBody('codefloe.com', 'owner', 'repo'),
+        ),
+        true,
+      );
+    });
+
+    test('rejects repo payloads missing the fields the source needs', () {
+      for (final String body in <String>[
+        '{}',
+        'not json',
+        '{"name":"repo"}',
+        '{"name":"repo","full_name":"repo","owner":{"login":"owner"}}',
+        '{"name":"repo","full_name":"owner/repo"}',
+        '{"name":"repo","full_name":"owner/repo","owner":"owner"}',
+        '{"full_name":"owner/repo","owner":{"login":"owner"}}',
+      ]) {
+        expect(ForgejoDetector.looksLikeRepoPayload(body), false, reason: body);
+      }
+    });
+  });
+
+  group('detect', () {
+    test('confirms a Forgejo repo with one probe per endpoint', () async {
+      final _FakeForge forge = _workingForge();
+      final ForgejoDetection? detection = await ForgejoDetector.detect(
+        'https://codefloe.com/SnappTechnology/NextCloudTalkNext/releases',
+        probe: forge.probe,
+      );
+      expect(detection, isNotNull);
+      expect(
+        detection!.canonicalUrl,
+        'https://codefloe.com/SnappTechnology/NextCloudTalkNext',
+      );
+      expect(detection.authority, 'codefloe.com');
+      expect(detection.sourceIdentifier, Codeberg().sourceIdentifier);
+      expect(forge.requested, <String>[
+        'https://codefloe.com/api/v1/version',
+        'https://codefloe.com/api/v1/repos/SnappTechnology/NextCloudTalkNext',
+      ]);
+    });
+
+    test('stops at the version probe when the host is not a forge', () async {
+      final _FakeForge forge = _FakeForge(<String, http.Response>{});
+      expect(
+        await ForgejoDetector.detect(
+          'https://example.com/owner/repo',
+          probe: forge.probe,
+        ),
+        isNull,
+      );
+      expect(forge.requested, <String>['https://example.com/api/v1/version']);
+    });
+
+    test('rejects a host answering the endpoint with something else', () async {
+      final _FakeForge forge = _FakeForge(<String, http.Response>{
+        'https://example.com/api/v1/version': http.Response(
+          '{"status":"ok"}',
+          200,
+        ),
+      });
+      expect(
+        await ForgejoDetector.detect(
+          'https://example.com/owner/repo',
+          probe: forge.probe,
+        ),
+        isNull,
+      );
+      expect(forge.requested.length, 1);
+    });
+
+    test('rejects a Forgejo host when the repo does not exist', () async {
+      final _FakeForge forge = _FakeForge(<String, http.Response>{
+        'https://codefloe.com/api/v1/version': http.Response(
+          _forgejoVersionBody,
+          200,
+        ),
+      });
+      expect(
+        await ForgejoDetector.detect(
+          'https://codefloe.com/owner/nope',
+          probe: forge.probe,
+        ),
+        isNull,
+      );
+      expect(forge.requested.length, 2);
+    });
+
+    test('probes each host only once, positive or negative', () async {
+      final _FakeForge forge = _workingForge();
+      forge.responses['https://codefloe.com/api/v1/repos/other/thing'] =
+          http.Response(_repoBody('codefloe.com', 'other', 'thing'), 200);
+
+      expect(
+        await ForgejoDetector.detect(
+          'https://codefloe.com/SnappTechnology/NextCloudTalkNext',
+          probe: forge.probe,
+        ),
+        isNotNull,
+      );
+      expect(
+        await ForgejoDetector.detect(
+          'https://codefloe.com/other/thing',
+          probe: forge.probe,
+        ),
+        isNotNull,
+      );
+      expect(
+        forge.requested
+            .where((String url) => url.endsWith('/api/v1/version'))
+            .length,
+        1,
+      );
+
+      final _FakeForge dud = _FakeForge(<String, http.Response>{});
+      await ForgejoDetector.detect(
+        'https://example.com/owner/repo',
+        probe: dud.probe,
+      );
+      await ForgejoDetector.detect(
+        'https://example.com/owner/other',
+        probe: dud.probe,
+      );
+      expect(dud.requested, <String>['https://example.com/api/v1/version']);
+    });
+
+    test('does not cache a verdict when the probe itself failed', () async {
+      int attempts = 0;
+      Future<http.Response> flaky(String url) async {
+        attempts++;
+        if (attempts == 1) throw const SocketExceptionStub();
+        return url.endsWith('/api/v1/version')
+            ? http.Response(_forgejoVersionBody, 200)
+            : http.Response(
+                _repoBody('codefloe.com', 'owner', 'repo'),
+                200,
+              );
+      }
+
+      expect(
+        await ForgejoDetector.detect(
+          'https://codefloe.com/owner/repo',
+          probe: flaky,
+        ),
+        isNull,
+      );
+      // The failure was not recorded as "not a forge", so a retry can succeed.
+      expect(
+        await ForgejoDetector.detect(
+          'https://codefloe.com/owner/repo',
+          probe: flaky,
+        ),
+        isNotNull,
+      );
+    });
+  });
+
+  group('detectIfUnmatched', () {
+    test('leaves URLs that already resolve to a real source alone', () async {
+      final _FakeForge forge = _workingForge(host: 'github.com');
+      expect(
+        await ForgejoDetector.detectIfUnmatched(
+          'https://github.com/SnappTechnology/NextCloudTalkNext',
+          probe: forge.probe,
+        ),
+        isNull,
+      );
+      expect(
+        await ForgejoDetector.detectIfUnmatched(
+          'https://codeberg.org/Freeyourgadget/Gadgetbridge',
+          probe: forge.probe,
+        ),
+        isNull,
+      );
+      expect(forge.requested, isEmpty);
+    });
+
+    test('runs for a host that would otherwise be scraped as HTML', () async {
+      final _FakeForge forge = _workingForge();
+      final ForgejoDetection? detection =
+          await ForgejoDetector.detectIfUnmatched(
+            'https://codefloe.com/SnappTechnology/NextCloudTalkNext',
+            probe: forge.probe,
+          );
+      expect(detection?.sourceIdentifier, Codeberg().sourceIdentifier);
+      expect(forge.requested.length, 2);
+    });
+  });
+}
+
+/// Stands in for a transport failure without depending on dart:io in a test.
+class SocketExceptionStub implements Exception {
+  const SocketExceptionStub();
+}

--- a/test/forgejo_detection_test.dart
+++ b/test/forgejo_detection_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:obtainium/app_sources/codeberg.dart';
+import 'package:obtainium/providers/source_provider.dart';
 import 'package:obtainium/services/forgejo_detection.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -36,7 +37,7 @@ class _FakeForge {
 }
 
 _FakeForge _workingForge({
-  String host = 'codefloe.com',
+  String host = 'forgejo.example.org',
   String owner = 'SnappTechnology',
   String repo = 'NextCloudTalkNext',
 }) => _FakeForge(<String, http.Response>{
@@ -211,19 +212,19 @@ void main() {
     test('confirms a Forgejo repo with one probe per endpoint', () async {
       final _FakeForge forge = _workingForge();
       final ForgejoDetection? detection = await ForgejoDetector.detect(
-        'https://codefloe.com/SnappTechnology/NextCloudTalkNext/releases',
+        'https://forgejo.example.org/SnappTechnology/NextCloudTalkNext/releases',
         probe: forge.probe,
       );
       expect(detection, isNotNull);
       expect(
         detection!.canonicalUrl,
-        'https://codefloe.com/SnappTechnology/NextCloudTalkNext',
+        'https://forgejo.example.org/SnappTechnology/NextCloudTalkNext',
       );
-      expect(detection.authority, 'codefloe.com');
+      expect(detection.authority, 'forgejo.example.org');
       expect(detection.sourceIdentifier, Codeberg().sourceIdentifier);
       expect(forge.requested, <String>[
-        'https://codefloe.com/api/v1/version',
-        'https://codefloe.com/api/v1/repos/SnappTechnology/NextCloudTalkNext',
+        'https://forgejo.example.org/api/v1/version',
+        'https://forgejo.example.org/api/v1/repos/SnappTechnology/NextCloudTalkNext',
       ]);
     });
 
@@ -258,14 +259,14 @@ void main() {
 
     test('rejects a Forgejo host when the repo does not exist', () async {
       final _FakeForge forge = _FakeForge(<String, http.Response>{
-        'https://codefloe.com/api/v1/version': http.Response(
+        'https://forgejo.example.org/api/v1/version': http.Response(
           _forgejoVersionBody,
           200,
         ),
       });
       expect(
         await ForgejoDetector.detect(
-          'https://codefloe.com/owner/nope',
+          'https://forgejo.example.org/owner/nope',
           probe: forge.probe,
         ),
         isNull,
@@ -275,19 +276,19 @@ void main() {
 
     test('probes each host only once, positive or negative', () async {
       final _FakeForge forge = _workingForge();
-      forge.responses['https://codefloe.com/api/v1/repos/other/thing'] =
-          http.Response(_repoBody('codefloe.com', 'other', 'thing'), 200);
+      forge.responses['https://forgejo.example.org/api/v1/repos/other/thing'] =
+          http.Response(_repoBody('forgejo.example.org', 'other', 'thing'), 200);
 
       expect(
         await ForgejoDetector.detect(
-          'https://codefloe.com/SnappTechnology/NextCloudTalkNext',
+          'https://forgejo.example.org/SnappTechnology/NextCloudTalkNext',
           probe: forge.probe,
         ),
         isNotNull,
       );
       expect(
         await ForgejoDetector.detect(
-          'https://codefloe.com/other/thing',
+          'https://forgejo.example.org/other/thing',
           probe: forge.probe,
         ),
         isNotNull,
@@ -319,14 +320,14 @@ void main() {
         return url.endsWith('/api/v1/version')
             ? http.Response(_forgejoVersionBody, 200)
             : http.Response(
-                _repoBody('codefloe.com', 'owner', 'repo'),
+                _repoBody('forgejo.example.org', 'owner', 'repo'),
                 200,
               );
       }
 
       expect(
         await ForgejoDetector.detect(
-          'https://codefloe.com/owner/repo',
+          'https://forgejo.example.org/owner/repo',
           probe: flaky,
         ),
         isNull,
@@ -334,7 +335,7 @@ void main() {
       // The failure was not recorded as "not a forge", so a retry can succeed.
       expect(
         await ForgejoDetector.detect(
-          'https://codefloe.com/owner/repo',
+          'https://forgejo.example.org/owner/repo',
           probe: flaky,
         ),
         isNotNull,
@@ -359,6 +360,15 @@ void main() {
         ),
         isNull,
       );
+      // A seeded Forgejo host is matched synchronously, so it must never pay
+      // for a probe. This is the whole point of keeping entries in `hosts`.
+      expect(
+        await ForgejoDetector.detectIfUnmatched(
+          'https://codefloe.com/SnappTechnology/NextCloudTalkNext',
+          probe: forge.probe,
+        ),
+        isNull,
+      );
       expect(forge.requested, isEmpty);
     });
 
@@ -366,7 +376,7 @@ void main() {
       final _FakeForge forge = _workingForge();
       final ForgejoDetection? detection =
           await ForgejoDetector.detectIfUnmatched(
-            'https://codefloe.com/SnappTechnology/NextCloudTalkNext',
+            'https://forgejo.example.org/SnappTechnology/NextCloudTalkNext',
             probe: forge.probe,
           );
       expect(detection?.sourceIdentifier, Codeberg().sourceIdentifier);
@@ -375,10 +385,29 @@ void main() {
   });
 
   group('Codeberg on a non-codeberg host', () {
+    test('a seeded host resolves to the Forgejo source, no override', () {
+      expect(
+        SourceProvider().getSourceTemplate('https://codefloe.com/owner/repo'),
+        isA<Codeberg>(),
+      );
+    });
+
+    test('a seeded host gets native URL standardization', () {
+      // The override path cannot trim the URL (standardizeUrl skips
+      // source-specific standardization once the host has been overridden),
+      // which is why ForgejoDetector hands back a canonical URL instead. A
+      // host in `hosts` needs no such help.
+      const String url = 'https://codefloe.com/owner/repo/releases';
+      expect(
+        SourceProvider().getSource(url).standardizeUrl(url),
+        'https://codefloe.com/owner/repo',
+      );
+    });
+
     test('infers the app ID from the app URL host, never hosts[0]', () async {
       final _RecordingCodeberg source = _RecordingCodeberg();
-      // Mirrors what getSource does for a detected instance, so the test still
-      // holds if `hosts` is ever seeded with more than one entry.
+      // Pinned rather than relying on the shipped list: what matters is that
+      // the target host is not hosts[0], whatever `hosts` grows into.
       source.hosts = <String>['codeberg.org', 'codefloe.com'];
 
       await source.tryInferringAppId('https://codefloe.com/owner/repo');

--- a/test/forgejo_detection_test.dart
+++ b/test/forgejo_detection_test.dart
@@ -373,9 +373,55 @@ void main() {
       expect(forge.requested.length, 2);
     });
   });
+
+  group('Codeberg on a non-codeberg host', () {
+    test('infers the app ID from the app URL host, never hosts[0]', () async {
+      final _RecordingCodeberg source = _RecordingCodeberg();
+      // Mirrors what getSource does for a detected instance, so the test still
+      // holds if `hosts` is ever seeded with more than one entry.
+      source.hosts = <String>['codeberg.org', 'codefloe.com'];
+
+      await source.tryInferringAppId('https://codefloe.com/owner/repo');
+
+      expect(source.requested, isNotEmpty);
+      for (final String url in source.requested) {
+        expect(
+          url,
+          startsWith('https://codefloe.com/api/v1/repos/owner/repo/contents/'),
+          reason: url,
+        );
+      }
+    });
+
+    test('keeps the scheme and port of a self-hosted instance', () async {
+      final _RecordingCodeberg source = _RecordingCodeberg();
+      await source.tryInferringAppId('http://git.example.com:3000/o/r');
+      expect(
+        source.requested.first,
+        startsWith('http://git.example.com:3000/api/v1/repos/o/r/contents/'),
+      );
+    });
+  });
 }
 
 /// Stands in for a transport failure without depending on dart:io in a test.
 class SocketExceptionStub implements Exception {
   const SocketExceptionStub();
+}
+
+/// Records the URLs the source would fetch, and answers every one of them 404
+/// so app-ID inference walks its whole candidate list and gives up.
+class _RecordingCodeberg extends Codeberg {
+  final List<String> requested = <String>[];
+
+  @override
+  Future<http.Response> sourceRequest(
+    String url,
+    Map<String, dynamic> additionalSettings, {
+    bool followRedirects = true,
+    Object? postBody,
+  }) async {
+    requested.add(url);
+    return http.Response('{}', 404);
+  }
 }


### PR DESCRIPTION
`codeberg.org` is the only Forgejo host ObtainX matches by name, so a repo on any other instance falls through to the `HTML` catch-all and gets scraped as a rendered release page instead of queried through the instance's JSON API. That is heavier and more fragile, and it is what CodeFloe's maintainers traced their rate limiting to. They asked for auto-detection of any Forgejo host rather than a Codeberg special case (see [their write-up](https://forum.codefloe.com/t/obtainium-hitting-rate-limit/148) and #254).

## Approach

Source matching is synchronous and cached, so detection can't live inside it: a probe is a network round-trip. Instead `ForgejoDetector` runs where a URL first enters the app (the Add App form and `getAppsByURLNaive`) and, on a match, selects the Forgejo adapter through the existing per-app `overrideSource`.

That is exactly what a user does by hand under **Override source → Forgejo (Codeberg)**, which is deliberate: the result persists with the app, survives export/import, and stays visible and editable in the dropdown. No new stored state, no migration, and a wrong guess is one selection away from being corrected.

The probe is two requests and stops at the first:

```
1. GET <origin>/api/v1/version         -> 200 {"version": "16.0.2"}
2. GET <origin>/api/v1/repos/<o>/<r>   -> 200 {"name", "full_name", "owner"}
```

Step 1 rules out virtually every non-forge host in a single request, and its verdict is cached per authority for the process lifetime, so importing twenty repos from one instance probes it once. A request that never completed (offline, DNS, timeout) is deliberately left uncached, so a moment without network can't blacklist an instance for the whole session. Step 2 confirms the path really is a repository and that the API answers in the shape `Codeberg` reads.

Detection only runs for URLs that would otherwise fall through to `HTML`; anything already matching a real source is left alone.

## Notes

**The detected URL is snapped to `<owner>/<repo>`.** An overridden source keeps the URL's path verbatim when building API calls, so `.../repo/releases` would become `.../repos/owner/repo/releases`. `standardizeUrl` can't trim it either, because it skips source-specific standardization whenever the host was overridden.

**The override dropdown's `GeneratedForm` is now keyed to its value.** The form reads item values once in `initForm` and re-reads them only when its key changes, so the dropdown would otherwise still read "None" after detection had set the override.

## Testing

Verified on Flutter 3.47.1 / Dart 3.13.1:

- `flutter analyze`: no issues
- `flutter test`: 291 passed, 1 skipped (pre-existing), 0 failed
- New `test/forgejo_detection_test.dart`: 19 tests covering URL parsing (extra path segments, `.git` suffix, ports, scheme-less input, Forgejo's reserved top-level routes), payload validation, per-host probe caching in both directions, no caching after a transport failure, and the no-probe path for URLs that already resolve to a real source

Probe endpoints and payload shapes were checked against live `codefloe.com` and `codeberg.org`.

## Not included

The CodeFloe thread raises two further points I left out. Happy to follow up on either, here or separately:

- **A User-Agent on source requests.** There is no default today, so requests go out as `Dart/3.x (dart:io)`. Worth doing for every forge, not just Forgejo.
- **Renaming `Codeberg` to `Forgejo`.** The class name is the persisted `overrideSource` identifier on every existing app, so it needs a migration in `appJSONCompatibilityModifiers()`. Kept out of this PR to hold the blast radius down.

Closes #254
